### PR TITLE
Integrate API service into WPF client

### DIFF
--- a/IISApp/CountriesWindow.xaml.cs
+++ b/IISApp/CountriesWindow.xaml.cs
@@ -1,17 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
+using System;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using IISApp.Services;
 
 namespace IISApp
 {
@@ -20,29 +9,23 @@ namespace IISApp
     /// </summary>
     public partial class CountriesWindow : Window
     {
-        private readonly string _jwtToken;
+        private readonly ApiService _api;
 
-        public CountriesWindow(string jwtToken)
+        public CountriesWindow(ApiService api)
         {
             InitializeComponent();
-            _jwtToken = jwtToken;
+            _api = api;
         }
 
         private async void SearchButton_Click(object sender, RoutedEventArgs e)
         {
             string country = CountryTextBox.Text;
             string year = YearTextBox.Text;
-            string requestUrl = $"http://localhost:8080/countries?country={country}&year={year}";
 
             try
             {
-                using HttpClient client = new HttpClient();
-                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {_jwtToken}");
-                HttpResponseMessage response = await client.GetAsync(requestUrl);
-                response.EnsureSuccessStatusCode();
-
-                string responseContent = await response.Content.ReadAsStringAsync();
-                ResponseTextBox.Text = responseContent;
+                string response = await _api.GetCountriesAsync(country, year);
+                ResponseTextBox.Text = response;
             }
             catch (Exception ex)
             {
@@ -51,4 +34,3 @@ namespace IISApp
         }
     }
 }
-

--- a/IISApp/IISApp.csproj
+++ b/IISApp/IISApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -7,9 +7,5 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
 
 </Project>

--- a/IISApp/LoginWindow.xaml.cs
+++ b/IISApp/LoginWindow.xaml.cs
@@ -1,19 +1,6 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using IISApp.Services;
 
 namespace IISApp
 {
@@ -22,11 +9,12 @@ namespace IISApp
     /// </summary>
     public partial class LoginWindow : Window
     {
-        public string JwtToken { get; private set; }
+        private readonly ApiService _api;
 
-        public LoginWindow()
+        public LoginWindow(ApiService api)
         {
             InitializeComponent();
+            _api = api;
         }
 
         private async void LoginButton_Click(object sender, RoutedEventArgs e)
@@ -34,30 +22,19 @@ namespace IISApp
             string username = UsernameTextBox.Text.Trim();
             string password = PasswordBox.Password.Trim();
 
-            string jsonBody = $"{{\"username\":\"{username}\",\"password\":\"{password}\"}}";
-
             try
             {
-                using HttpClient client = new HttpClient();
-                StringContent content = new StringContent(jsonBody, new UTF8Encoding(false), "application/json");
-
-                HttpResponseMessage response = await client.PostAsync("http://localhost:8080/api/auth/login", content);
-                response.EnsureSuccessStatusCode();
-
-
-                string responseContent = await response.Content.ReadAsStringAsync();
-                JwtToken = responseContent.Trim();
-
-                if (!string.IsNullOrEmpty(JwtToken))
+                bool success = await _api.LoginAsync(username, password);
+                if (success)
                 {
                     LoginStatusTextBlock.Text = "Login successful!";
-                    CountriesWindow countriesWindow = new CountriesWindow(JwtToken);
+                    CountriesWindow countriesWindow = new CountriesWindow(_api);
                     countriesWindow.Show();
                     this.Close();
                 }
                 else
                 {
-                    LoginStatusTextBlock.Text = "Login failed: No token received.";
+                    LoginStatusTextBlock.Text = "Login failed.";
                 }
             }
             catch (Exception ex)
@@ -66,7 +43,4 @@ namespace IISApp
             }
         }
     }
-
-
 }
-

--- a/IISApp/MainWindow.xaml.cs
+++ b/IISApp/MainWindow.xaml.cs
@@ -1,13 +1,5 @@
-﻿using System.Text;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using IISApp.Services;
 
 namespace IISApp
 {
@@ -16,13 +8,16 @@ namespace IISApp
     /// </summary>
     public partial class MainWindow : Window
     {
+        private readonly ApiService _api;
+
         public MainWindow()
         {
             InitializeComponent();
+            _api = new ApiService("http://localhost:8080");
         }
         private void OpenLoginWindowButton_Click(object sender, RoutedEventArgs e)
         {
-            LoginWindow loginWindow = new LoginWindow();
+            LoginWindow loginWindow = new LoginWindow(_api);
             loginWindow.Show();
         }
 

--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace IISApp.Services
+{
+    public class ApiService
+    {
+        private readonly HttpClient _http;
+
+        public string? AccessToken { get; private set; }
+        public string? RefreshToken { get; private set; }
+
+        public ApiService(string baseUrl)
+        {
+            _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        }
+
+        public async Task<bool> LoginAsync(string username, string password)
+        {
+            var payload = new { username, password };
+            var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+            var response = await _http.PostAsync("/api/auth/login", content);
+            if (!response.IsSuccessStatusCode)
+                return false;
+
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            AccessToken = doc.RootElement.GetProperty("accessToken").GetString();
+            RefreshToken = doc.RootElement.TryGetProperty("refreshToken", out var refresh) ? refresh.GetString() : null;
+            return !string.IsNullOrEmpty(AccessToken);
+        }
+
+        private void ApplyHeaders()
+        {
+            if (!string.IsNullOrEmpty(AccessToken))
+            {
+                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            }
+        }
+
+        public async Task<string> GetCountriesAsync(string country, string year)
+        {
+            ApplyHeaders();
+            var url = $"/countries?country={country}&year={year}";
+            return await _http.GetStringAsync(url);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ApiService` to handle JWT login and country queries
- Wire `LoginWindow` and `CountriesWindow` to use the shared API service
- Drop unused Newtonsoft.Json reference

## Testing
- ⚠️ `dotnet build` *(missing: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b5efa96044832aba921c7ad329771c