### PR TITLE
Integrate ApiService with validation and normalize schema selection

### DIFF
--- a/IISApp/MainWindow.xaml.cs
+++ b/IISApp/MainWindow.xaml.cs
@@ -15,7 +15,7 @@ namespace IISApp
         {
             InitializeComponent();
             _api = new ApiService("http://localhost:8080");
-            _validator = new ValidationService("http://localhost:8080");
+            _validator = new ValidationService(_api);
         }
         private void OpenLoginWindowButton_Click(object sender, RoutedEventArgs e)
         {

--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -45,7 +45,7 @@ namespace IISApp
         private string GetSelectedSchema()
         {
             if (SchemaComboBox.SelectedItem is System.Windows.Controls.ComboBoxItem item)
-                return item.Content?.ToString() ?? "xsd";
+                return item.Content?.ToString()?.ToLowerInvariant() ?? "xsd";
             return "xsd";
         }
 

--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -10,6 +10,7 @@ namespace IISApp.Services
     public class ApiService
     {
         private readonly HttpClient _http;
+        public HttpClient HttpClient => _http;
 
         public string? AccessToken { get; private set; }
         public string? RefreshToken { get; private set; }
@@ -43,7 +44,7 @@ namespace IISApp.Services
             return !string.IsNullOrEmpty(AccessToken);
         }
 
-        private void ApplyHeaders()
+        public void ApplyHeaders()
         {
             if (!string.IsNullOrEmpty(AccessToken))
             {

--- a/IISApp/Services/ValidationService.cs
+++ b/IISApp/Services/ValidationService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,27 +6,30 @@ namespace IISApp.Services
 {
     public class ValidationService
     {
-        private readonly HttpClient _http;
+        private readonly ApiService _api;
 
-        public ValidationService(string baseUrl)
+        public ValidationService(ApiService api)
         {
-            _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
+            _api = api;
         }
 
         public async Task<string> ValidateAsync(string xml, string schema)
         {
-            var url = $"/validate?schema={schema}";
+            _api.ApplyHeaders();
+            var url = $"/validate?schema={schema.ToLowerInvariant()}";
             var content = new StringContent(xml, Encoding.UTF8, "application/xml");
-            var response = await _http.PostAsync(url, content);
+            var response = await _api.HttpClient.PostAsync(url, content);
             return await response.Content.ReadAsStringAsync();
         }
 
         public async Task<string> ValidateAndSaveAsync(string xml, string schema)
         {
-            var url = $"/validateAndSaveXml?schema={schema}";
+            _api.ApplyHeaders();
+            var url = $"/validateAndSaveXml?schema={schema.ToLowerInvariant()}";
             var content = new StringContent(xml, Encoding.UTF8, "application/xml");
-            var response = await _http.PostAsync(url, content);
+            var response = await _api.HttpClient.PostAsync(url, content);
             return await response.Content.ReadAsStringAsync();
         }
     }
 }
+

--- a/IISApp/ValidateAndSaveWindow.xaml.cs
+++ b/IISApp/ValidateAndSaveWindow.xaml.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using IISApp.Services;
@@ -11,14 +8,14 @@ namespace IISApp
     {
         private readonly ValidationService _validator;
 
-        public ValidateAndSaveWindow() : this(new ValidationService("http://localhost:8080"))
+        public ValidateAndSaveWindow() : this(new ApiService("http://localhost:8080"))
         {
         }
 
-        public ValidateAndSaveWindow(ValidationService validator)
+        public ValidateAndSaveWindow(ApiService api)
         {
             InitializeComponent();
-            _validator = validator;
+            _validator = new ValidationService(api);
         }
 
         private string BuildPlayerXml()
@@ -34,7 +31,7 @@ namespace IISApp
         private string GetSchema()
         {
             if (SchemaComboBox.SelectedItem is ComboBoxItem item)
-                return item.Content?.ToString() ?? "xsd";
+                return item.Content?.ToString()?.ToLowerInvariant() ?? "xsd";
             return "xsd";
         }
 
@@ -47,7 +44,7 @@ namespace IISApp
                 var result = await _validator.ValidateAsync(xml, schema);
                 ResponseTextBox.Text = result;
             }
-            catch (Exception ex)
+            catch (System.Exception ex)
             {
                 ResponseTextBox.Text = $"Error: {ex.Message}";
             }
@@ -62,10 +59,11 @@ namespace IISApp
                 var result = await _validator.ValidateAndSaveAsync(xml, schema);
                 ResponseTextBox.Text = result;
             }
-            catch (Exception ex)
+            catch (System.Exception ex)
             {
                 ResponseTextBox.Text = $"Error: {ex.Message}";
             }
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- Construct ValidationService with shared ApiService to reuse authentication
- Expose ApiService's HttpClient and ApplyHeaders for reuse
- Normalize schema selection to lowercase across windows

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b612a79a64832abaa32b480a0e74e1