### PR TITLE
Parse player responses from XML

### DIFF
--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -4,6 +4,8 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Linq;
 
 namespace IISApp.Services
 {
@@ -69,8 +71,28 @@ namespace IISApp.Services
             var response = await _http.GetAsync($"/api/players/{id}");
             if (!response.IsSuccessStatusCode)
                 return null;
-            var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<Models.Player>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            var xml = await response.Content.ReadAsStringAsync();
+            try
+            {
+                var doc = XDocument.Parse(xml);
+                var playerElement = doc.Descendants("Player").FirstOrDefault();
+                if (playerElement == null)
+                    return null;
+
+                return new Models.Player
+                {
+                    Id = (int?)playerElement.Element("id") ?? (int?)playerElement.Element("Id") ?? 0,
+                    Name = (string?)playerElement.Element("name") ?? (string?)playerElement.Element("Name"),
+                    Team = (string?)playerElement.Element("team") ?? (string?)playerElement.Element("Team"),
+                    Season = (string?)playerElement.Element("season") ?? (string?)playerElement.Element("Season"),
+                    Points = (double?)playerElement.Element("points") ?? (double?)playerElement.Element("Points") ?? 0
+                };
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         public async Task<Models.Player[]?> GetAllPlayersAsync()
@@ -78,9 +100,26 @@ namespace IISApp.Services
             ApplyHeaders();
             var response = await _http.GetAsync("/api/players");
             if (!response.IsSuccessStatusCode)
-                return null;
-            var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<Models.Player[]>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                return Array.Empty<Models.Player>();
+
+            var xml = await response.Content.ReadAsStringAsync();
+            try
+            {
+                var doc = XDocument.Parse(xml);
+                var players = doc.Descendants("Player").Select(p => new Models.Player
+                {
+                    Id = (int?)p.Element("id") ?? (int?)p.Element("Id") ?? 0,
+                    Name = (string?)p.Element("name") ?? (string?)p.Element("Name"),
+                    Team = (string?)p.Element("team") ?? (string?)p.Element("Team"),
+                    Season = (string?)p.Element("season") ?? (string?)p.Element("Season"),
+                    Points = (double?)p.Element("points") ?? (double?)p.Element("Points") ?? 0
+                }).ToArray();
+                return players;
+            }
+            catch
+            {
+                return Array.Empty<Models.Player>();
+            }
         }
 
         public async Task<bool> CreatePlayerAsync(Models.Player player)


### PR DESCRIPTION
## Summary
- switch `ApiService`'s player retrieval methods to parse XML `<Player>` nodes instead of JSON
- ensure failed requests return `null` or an empty collection as appropriate

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden; unable to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b83bf9e300832ab48286dcff080cfa