### PR TITLE
Align WPF frontend with backend API contract and improve demo readiness

### DIFF
--- a/IISApp.Tests/WeatherServiceClientTests.cs
+++ b/IISApp.Tests/WeatherServiceClientTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Globalization;
 using System.Reflection;
 using IISApp.Services;
 using Xunit;
@@ -8,29 +7,46 @@ namespace IISApp.Tests
 {
     public class WeatherServiceClientTests
     {
-        [Theory]
-        [InlineData("en-US")]
-        [InlineData("fr-FR")]
-        public void ParseTemperatures_UsesInvariantCulture(string culture)
+        [Fact]
+        public void ParseTemperatures_ParsesCityAndTemperatureRows()
         {
-            var xml = @"<?xml version=\"1.0\"?><methodResponse><params><param><value><array><data><value><struct>" +
-                      @"<member><name>city</name><value><string>London</string></value></member>" +
-                      @"<member><name>temperature</name><value><double>21.3</double></value></member>" +
-                      @"</struct></value></data></array></value></param></params></methodResponse>";
+            var xml = "<?xml version=\"1.0\"?><methodResponse><params><param><value><array><data>" +
+                      "<value><string>London: 21.3</string></value>" +
+                      "<value><string>Paris: 18.5</string></value>" +
+                      "</data></array></value></param></params></methodResponse>";
 
             var client = new WeatherServiceClient("http://localhost");
             var method = typeof(WeatherServiceClient).GetMethod("ParseTemperatures", BindingFlags.NonPublic | BindingFlags.Instance)!;
-            var originalCulture = CultureInfo.CurrentCulture;
-            try
-            {
-                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
-                var result = (Dictionary<string, double>)method.Invoke(client, new object[] { xml })!;
-                Assert.Equal(21.3, result["London"]);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = originalCulture;
-            }
+
+            var result = (List<WeatherResult>)method.Invoke(client, new object[] { xml })!;
+
+            Assert.Collection(result,
+                r =>
+                {
+                    Assert.Equal("London", r.City);
+                    Assert.Equal("21.3", r.Temperature);
+                },
+                r =>
+                {
+                    Assert.Equal("Paris", r.City);
+                    Assert.Equal("18.5", r.Temperature);
+                });
+        }
+
+        [Fact]
+        public void ParseTemperatures_ParsesCityNotFoundMessage()
+        {
+            var xml = "<?xml version=\"1.0\"?><methodResponse><params><param><value><array><data>" +
+                      "<value><string>City not found</string></value>" +
+                      "</data></array></value></param></params></methodResponse>";
+
+            var client = new WeatherServiceClient("http://localhost");
+            var method = typeof(WeatherServiceClient).GetMethod("ParseTemperatures", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+            var result = (List<WeatherResult>)method.Invoke(client, new object[] { xml })!;
+
+            Assert.Single(result);
+            Assert.Equal("City not found", result[0].Message);
         }
     }
 }

--- a/IISApp/App.config
+++ b/IISApp/App.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="ApiBaseUrl" value="http://localhost:8080" />
+    <add key="SoapBaseUrl" value="http://localhost:8080" />
+    <add key="WeatherServiceUrl" value="http://localhost:9090/RPC2" />
+    <add key="FrontendAccessMode" value="FullAccess" />
+  </appSettings>
+</configuration>

--- a/IISApp/CityWindow.xaml.cs
+++ b/IISApp/CityWindow.xaml.cs
@@ -1,16 +1,10 @@
-﻿using System;
+using System;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 using IISApp.Services;
-using System.Xml;
-using System.IO;
 
 namespace IISApp
 {
-    /// <summary>
-    /// Interaction logic for CityWindow.xaml
-    /// </summary>
     public partial class CityWindow : Window
     {
         private readonly WeatherServiceClient _client;
@@ -18,46 +12,33 @@ namespace IISApp
         public CityWindow()
         {
             InitializeComponent();
-            _client = new WeatherServiceClient("http://localhost:9090");
+            _client = new WeatherServiceClient(AppConfig.WeatherServiceUrl);
         }
 
         private async void SendXmlRpcRequestButton_Click(object sender, RoutedEventArgs e)
         {
-            string cityName = CityNameTextBox.Text.Trim();
+            var cityName = CityNameTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(cityName))
+            {
+                FormattedXmlTextBox.Text = "Please enter a city name.";
+                return;
+            }
+
             try
             {
                 var results = await _client.GetTemperaturesAsync(cityName);
-                // Convert Dictionary<string, double> to formatted XML string
-                string formattedXml = FormatDictionaryAsXml(results);
-                FormattedXmlTextBox.Text = formattedXml;
+                if (results.Count == 0)
+                {
+                    FormattedXmlTextBox.Text = "No weather results returned.";
+                    return;
+                }
+
+                FormattedXmlTextBox.Text = string.Join(Environment.NewLine, results.Select(r => r.ToString()));
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message);
+                FormattedXmlTextBox.Text = $"Weather service error: {ex.Message}";
             }
         }
-
-        // Helper method to convert Dictionary<string, double> to XML string
-        private string FormatDictionaryAsXml(System.Collections.Generic.Dictionary<string, double> dict)
-        {
-            var doc = new XmlDocument();
-            var root = doc.CreateElement("Temperatures");
-            doc.AppendChild(root);
-
-            foreach (var kvp in dict)
-            {
-                var cityElem = doc.CreateElement("City");
-                cityElem.InnerText = kvp.Value.ToString();
-                root.AppendChild(cityElem);
-            }
-
-            using (var stringWriter = new StringWriter())
-            using (var xmlTextWriter = new XmlTextWriter(stringWriter) { Formatting = Formatting.Indented })
-            {
-                doc.WriteTo(xmlTextWriter);
-                return stringWriter.ToString();
-            }
-        }
-
     }
 }

--- a/IISApp/IISApp.csproj
+++ b/IISApp/IISApp.csproj
@@ -8,4 +8,7 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/IISApp/LoginWindow.xaml.cs
+++ b/IISApp/LoginWindow.xaml.cs
@@ -4,47 +4,53 @@ using IISApp.Services;
 
 namespace IISApp
 {
-    /// <summary>
-    /// Interaction logic for LoginWindow.xaml
-    /// </summary>
     public partial class LoginWindow : Window
     {
         private readonly ApiService _api;
         private readonly ValidationService _validator;
+        private readonly PermissionService _permissionService;
 
-        public LoginWindow(ApiService api, ValidationService validator)
+        public LoginWindow(ApiService api, ValidationService validator, PermissionService permissionService)
         {
             InitializeComponent();
             _api = api;
             _validator = validator;
+            _permissionService = permissionService;
         }
-        // Add this property to the LoginWindow class to fix CS0103
-        public string AccessToken { get; private set; }
+
         private async void LoginButton_Click(object sender, RoutedEventArgs e)
         {
-            string username = UsernameTextBox.Text.Trim();
-            string password = PasswordBox.Password.Trim();
+            var username = UsernameTextBox.Text.Trim();
+            var password = PasswordBox.Password.Trim();
 
+            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
+            {
+                LoginStatusTextBlock.Text = "Enter username and password.";
+                return;
+            }
+
+            LoginButton.IsEnabled = false;
             try
             {
-                // ApiService.LoginAsync returns a bool, not a token string
-                bool loginSuccess = await _api.LoginAsync(username, password);
-                if (loginSuccess)
+                var loginSuccess = await _api.LoginAsync(username, password);
+                if (!loginSuccess)
                 {
-                    AccessToken = _api.AccessToken?.Trim(); // Get token from ApiService property
-                    LoginStatusTextBlock.Text = "Login successful!";
-                    PlayersWindow playersWindow = new PlayersWindow(_api, _validator);
-                    playersWindow.Show();
-                    this.Close();
+                    LoginStatusTextBlock.Text = "Login failed. Check credentials and backend status.";
+                    return;
                 }
-                else
-                {
-                    LoginStatusTextBlock.Text = "Login failed.";
-                }
+
+                LoginStatusTextBlock.Text = "Login successful.";
+                var playersWindow = new PlayersWindow(_api, _validator, _permissionService);
+                playersWindow.Show();
+                Close();
             }
             catch (Exception ex)
             {
                 LoginStatusTextBlock.Text = $"Login failed: {ex.Message}";
+            }
+            finally
+            {
+                LoginButton.IsEnabled = true;
             }
         }
     }

--- a/IISApp/MainWindow.xaml.cs
+++ b/IISApp/MainWindow.xaml.cs
@@ -3,41 +3,42 @@ using IISApp.Services;
 
 namespace IISApp
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
     public partial class MainWindow : Window
     {
         private readonly ApiService _api;
         private readonly ValidationService _validator;
+        private readonly PermissionService _permissionService;
 
         public MainWindow()
         {
             InitializeComponent();
-            _api = new ApiService("http://localhost:8080");
+            _api = new ApiService(AppConfig.ApiBaseUrl);
             _validator = new ValidationService(_api);
+            _permissionService = PermissionService.FromConfiguration();
         }
+
         private void OpenLoginWindowButton_Click(object sender, RoutedEventArgs e)
         {
-            LoginWindow loginWindow = new LoginWindow(_api, _validator);
+            var loginWindow = new LoginWindow(_api, _validator, _permissionService);
             loginWindow.Show();
         }
 
         private void OpenPlayersWindowButton_Click(object sender, RoutedEventArgs e)
         {
-            PlayersWindow playersWindow = new PlayersWindow(_api, _validator);
+            var playersWindow = new PlayersWindow(_api, _validator, _permissionService);
             playersWindow.Show();
         }
 
         private void OpenSOAPWindowButton_Click(object sender, RoutedEventArgs e)
         {
-            SOAPWindow soapWindow = new SOAPWindow();
+            var soapWindow = new SOAPWindow();
             soapWindow.Show();
         }
+
         private void OpenXRCPWindowButton_Click(object sender, RoutedEventArgs e)
         {
-            CityWindow soapWindow = new CityWindow();
-            soapWindow.Show();
+            var cityWindow = new CityWindow();
+            cityWindow.Show();
         }
     }
 }

--- a/IISApp/Models/Player.cs
+++ b/IISApp/Models/Player.cs
@@ -1,16 +1,29 @@
+using System.Globalization;
+using System.Text.Json.Serialization;
+
 namespace IISApp.Models
 {
     public class Player
     {
-        public int Id { get; set; }
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("name")]
         public string? Name { get; set; }
+
+        [JsonPropertyName("team")]
         public string? Team { get; set; }
-        public string? Season { get; set; }
+
+        [JsonPropertyName("season")]
+        public int Season { get; set; }
+
+        [JsonPropertyName("points")]
         public double Points { get; set; }
 
-        public override string? ToString()
+        public override string ToString()
         {
-            return $"Id: {Id}, Name: {Name}, Team: {Team}, Season: {Season}, Points: {Points}";
+            var idText = string.IsNullOrWhiteSpace(Id) ? "(new)" : Id;
+            return $"[{idText}] {Name} | {Team} | Season {Season} | Points {Points.ToString(CultureInfo.InvariantCulture)}";
         }
     }
 }

--- a/IISApp/PlayersWindow.xaml
+++ b/IISApp/PlayersWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="Players" Height="500" Width="800">
+        Title="Players" Height="560" Width="860">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -21,8 +21,8 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
-        <Label Grid.Row="0" Grid.Column="0" Content="Id:" Margin="5"/>
-        <TextBox x:Name="IdTextBox" Grid.Row="0" Grid.Column="1" Margin="5"/>
+        <Label Grid.Row="0" Grid.Column="0" Content="Record Id:" Margin="5"/>
+        <TextBox x:Name="IdTextBox" Grid.Row="0" Grid.Column="1" Margin="5" IsReadOnly="True"/>
 
         <Label Grid.Row="1" Grid.Column="0" Content="Name:" Margin="5"/>
         <TextBox x:Name="NameTextBox" Grid.Row="1" Grid.Column="1" Margin="5"/>
@@ -42,12 +42,19 @@
                 <ComboBoxItem Content="XSD" IsSelected="True"/>
                 <ComboBoxItem Content="RNG"/>
             </ComboBox>
-            <Button Content="Validate" Margin="5" Click="ValidateButton_Click"/>
-            <Button Content="Save" Margin="5" Click="SaveButton_Click"/>
-            <Button Content="Delete" Margin="5" Click="DeleteButton_Click"/>
+            <Button Content="Validate (uses save endpoint)" Margin="5" Click="ValidateButton_Click"/>
+            <Button x:Name="SaveButton" Content="Save" Margin="5" Click="SaveButton_Click"/>
+            <Button x:Name="DeleteButton" Content="Delete" Margin="5" Click="DeleteButton_Click"/>
             <Button Content="Load All" Margin="5" Click="LoadAllButton_Click"/>
+            <Button Content="New" Margin="5" Click="NewButton_Click"/>
+            <Button Content="Logout" Margin="5" Click="LogoutButton_Click"/>
         </StackPanel>
 
-        <ListBox x:Name="PlayersListBox" Grid.Row="7" Grid.ColumnSpan="2" Margin="5" />
+        <StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="5">
+            <TextBlock x:Name="AccessModeTextBlock" FontWeight="Bold" Margin="0,0,20,0" />
+            <TextBlock x:Name="StatusTextBlock" />
+        </StackPanel>
+
+        <ListBox x:Name="PlayersListBox" Grid.Row="7" Grid.ColumnSpan="2" Margin="5" SelectionChanged="PlayersListBox_SelectionChanged" />
     </Grid>
 </Window>

--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Text;
 using System.Windows;
+using System.Windows.Controls;
+using System.Xml.Linq;
 using IISApp.Models;
 using IISApp.Services;
 
@@ -10,87 +11,233 @@ namespace IISApp
     {
         private readonly ApiService _api;
         private readonly ValidationService _validator;
+        private readonly PermissionService _permissions;
 
-        public PlayersWindow(ApiService api, ValidationService validator)
+        public PlayersWindow(ApiService api, ValidationService validator, PermissionService permissions)
         {
             InitializeComponent();
             _api = api;
             _validator = validator;
+            _permissions = permissions;
+
+            _api.SessionExpired += OnSessionExpired;
+            ConfigurePermissions();
+            Loaded += (_, _) => _ = LoadPlayersAsync();
         }
 
-        private Player BuildPlayer(bool includeId = true)
+        private void ConfigurePermissions()
+        {
+            var isReadOnly = !_permissions.CanMutatePlayers;
+            SaveButton.IsEnabled = !isReadOnly;
+            DeleteButton.IsEnabled = !isReadOnly;
+            AccessModeTextBlock.Text = isReadOnly ? "Mode: Read-only" : "Mode: Full-access";
+        }
+
+        private Player BuildPlayerFromForm()
         {
             return new Player
             {
-                Id = int.TryParse(IdTextBox.Text, out var id) ? id : 0,
-                Name = NameTextBox.Text,
-                Team = TeamTextBox.Text,
-                Season = SeasonTextBox.Text,
-                Points = double.TryParse(PointsTextBox.Text, out var p) ? p : 0
+                Id = string.IsNullOrWhiteSpace(IdTextBox.Text) ? null : IdTextBox.Text.Trim(),
+                Name = NameTextBox.Text.Trim(),
+                Team = TeamTextBox.Text.Trim(),
+                Season = int.TryParse(SeasonTextBox.Text, out var season) ? season : 0,
+                Points = double.TryParse(PointsTextBox.Text, out var points) ? points : 0
             };
+        }
+
+        private void PopulateForm(Player player)
+        {
+            IdTextBox.Text = player.Id ?? string.Empty;
+            NameTextBox.Text = player.Name ?? string.Empty;
+            TeamTextBox.Text = player.Team ?? string.Empty;
+            SeasonTextBox.Text = player.Season.ToString();
+            PointsTextBox.Text = player.Points.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        private void ClearForm()
+        {
+            IdTextBox.Text = string.Empty;
+            NameTextBox.Text = string.Empty;
+            TeamTextBox.Text = string.Empty;
+            SeasonTextBox.Text = string.Empty;
+            PointsTextBox.Text = string.Empty;
+            PlayersListBox.SelectedItem = null;
         }
 
         private string BuildPlayerXml(Player player)
         {
-            var sb = new StringBuilder();
-            sb.Append("<Players><Player>");
-            sb.Append($"<name>{player.Name}</name>");
-            sb.Append($"<team>{player.Team}</team>");
-            sb.Append($"<season>{player.Season}</season>");
-            sb.Append($"<points>{player.Points}</points>");
-            sb.Append("</Player></Players>");
-            return sb.ToString();
+            var xml = new XElement("Players",
+                new XElement("Player",
+                    new XElement("name", player.Name ?? string.Empty),
+                    new XElement("team", player.Team ?? string.Empty),
+                    new XElement("season", player.Season),
+                    new XElement("points", player.Points.ToString(System.Globalization.CultureInfo.InvariantCulture))));
+
+            return xml.ToString(SaveOptions.DisableFormatting);
         }
 
         private string GetSelectedSchema()
         {
-            if (SchemaComboBox.SelectedItem is System.Windows.Controls.ComboBoxItem item)
+            if (SchemaComboBox.SelectedItem is ComboBoxItem item)
+            {
                 return item.Content?.ToString()?.ToLowerInvariant() ?? "xsd";
+            }
+
             return "xsd";
+        }
+
+        private async System.Threading.Tasks.Task LoadPlayersAsync()
+        {
+            if (!_api.IsAuthenticated)
+            {
+                StatusTextBlock.Text = "Please login to load players.";
+                return;
+            }
+
+            var players = await _api.GetAllPlayersAsync();
+            PlayersListBox.ItemsSource = players;
+            StatusTextBlock.Text = $"Loaded {players?.Length ?? 0} players.";
         }
 
         private async void LoadAllButton_Click(object sender, RoutedEventArgs e)
         {
-            var players = await _api.GetAllPlayersAsync();
-            PlayersListBox.ItemsSource = players;
+            await LoadPlayersAsync();
         }
 
         private async void SaveButton_Click(object sender, RoutedEventArgs e)
         {
-            var player = BuildPlayer();
-            var xml = BuildPlayerXml(player);
-            var schema = GetSelectedSchema();
-            if (player.Id > 0)
+            if (!_permissions.CanMutatePlayers)
             {
-                var success = await _api.UpdatePlayerAsync(player);
-                MessageBox.Show(success ? "Saved" : "Save failed");
-            }
-            else
-            {
-                var result = await _validator.ValidateAndSaveAsync(xml, schema);
-                MessageBox.Show(result, "Validation result");
+                MessageBox.Show("Read-only mode is enabled. Save is disabled.");
+                return;
             }
 
-            LoadAllButton_Click(sender, e);
+            if (!_api.IsAuthenticated)
+            {
+                MessageBox.Show("Please login first.");
+                return;
+            }
+
+            var player = BuildPlayerFromForm();
+            if (string.IsNullOrWhiteSpace(player.Name) || string.IsNullOrWhiteSpace(player.Team) || player.Season <= 0)
+            {
+                MessageBox.Show("Name, team, and season are required.");
+                return;
+            }
+
+            try
+            {
+                Player? result;
+                if (string.IsNullOrWhiteSpace(player.Id))
+                {
+                    result = await _api.CreatePlayerAsync(player);
+                    MessageBox.Show(result is null ? "Create failed." : "Player created.");
+                }
+                else
+                {
+                    result = await _api.UpdatePlayerAsync(player);
+                    MessageBox.Show(result is null ? "Update failed." : "Player updated.");
+                }
+
+                await LoadPlayersAsync();
+                if (result is not null)
+                {
+                    PopulateForm(result);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Save failed: {ex.Message}");
+            }
         }
 
         private async void DeleteButton_Click(object sender, RoutedEventArgs e)
         {
-            if (int.TryParse(IdTextBox.Text, out var id) && id > 0)
+            if (!_permissions.CanMutatePlayers)
             {
-                var success = await _api.DeletePlayerAsync(id);
-                MessageBox.Show(success ? "Deleted" : "Delete failed");
-                LoadAllButton_Click(sender, e);
+                MessageBox.Show("Read-only mode is enabled. Delete is disabled.");
+                return;
+            }
+
+            var recordId = IdTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(recordId))
+            {
+                MessageBox.Show("Select a player first.");
+                return;
+            }
+
+            var confirm = MessageBox.Show($"Delete player {recordId}?", "Confirm delete", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (confirm != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            var success = await _api.DeletePlayerAsync(recordId);
+            MessageBox.Show(success ? "Player deleted." : "Delete failed.");
+
+            if (success)
+            {
+                ClearForm();
+                await LoadPlayersAsync();
             }
         }
 
         private async void ValidateButton_Click(object sender, RoutedEventArgs e)
         {
-            var player = BuildPlayer();
+            var player = BuildPlayerFromForm();
             var xml = BuildPlayerXml(player);
             var schema = GetSelectedSchema();
             var result = await _validator.ValidateAndSaveAsync(xml, schema);
-            MessageBox.Show(result, "Validation result");
+            MessageBox.Show(result, "Validate & Save result");
+        }
+
+        private async void PlayersListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (PlayersListBox.SelectedItem is not Player selectedPlayer)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(selectedPlayer.Id))
+            {
+                PopulateForm(selectedPlayer);
+                return;
+            }
+
+            var detailed = await _api.GetPlayerByIdAsync(selectedPlayer.Id);
+            PopulateForm(detailed ?? selectedPlayer);
+        }
+
+        private void NewButton_Click(object sender, RoutedEventArgs e)
+        {
+            ClearForm();
+            StatusTextBlock.Text = "Creating a new player.";
+        }
+
+        private void LogoutButton_Click(object sender, RoutedEventArgs e)
+        {
+            _api.Logout();
+            MessageBox.Show("Logged out.");
+            var loginWindow = new LoginWindow(_api, _validator, _permissions);
+            loginWindow.Show();
+            Close();
+        }
+
+        private void OnSessionExpired()
+        {
+            Dispatcher.Invoke(() =>
+            {
+                MessageBox.Show("Session expired. Please login again.");
+                var loginWindow = new LoginWindow(_api, _validator, _permissions);
+                loginWindow.Show();
+                Close();
+            });
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _api.SessionExpired -= OnSessionExpired;
+            base.OnClosed(e);
         }
     }
 }

--- a/IISApp/SOAPWindow.xaml.cs
+++ b/IISApp/SOAPWindow.xaml.cs
@@ -1,12 +1,10 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Windows;
 using IISApp.Services;
 
 namespace IISApp
 {
-    /// <summary>
-    /// Interaction logic for SOAPWindow.xaml
-    /// </summary>
     public partial class SOAPWindow : Window
     {
         private readonly SoapService _soap;
@@ -14,23 +12,23 @@ namespace IISApp
         public SOAPWindow()
         {
             InitializeComponent();
-            _soap = new SoapService("http://localhost:8080");
+            _soap = new SoapService(AppConfig.SoapBaseUrl);
         }
 
         private async void SendSOAPRequestButton_Click(object sender, RoutedEventArgs e)
         {
-            string searchTerm = SearchTermTextBox.Text;
+            var searchTerm = SearchTermTextBox.Text.Trim();
             try
             {
                 var players = await _soap.SearchPlayersAsync(searchTerm);
-                // FIX: Use p.ToString() instead of p.ToString to get the string representation.
-                PlayersTextBox.Text = string.Join(Environment.NewLine, players.Select(p => p.ToString()));
+                PlayersTextBox.Text = players.Length == 0
+                    ? "No players matched the SOAP search term."
+                    : string.Join(Environment.NewLine, players.Select(p => p.ToString()));
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message);
+                PlayersTextBox.Text = $"SOAP error: {ex.Message}";
             }
         }
     }
 }
-

--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -1,148 +1,220 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using System.Xml.Linq;
-using System.Linq;
+using IISApp.Models;
 
 namespace IISApp.Services
 {
     public class ApiService
     {
         private readonly HttpClient _http;
-        public HttpClient HttpClient => _http;
-
-        public string? AccessToken { get; private set; }
-        public string? RefreshToken { get; private set; }
+        private readonly JsonSerializerOptions _jsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
 
         public ApiService(string baseUrl)
         {
             _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
         }
 
+        public HttpClient HttpClient => _http;
+
+        public string? AccessToken { get; private set; }
+        public string? RefreshToken { get; private set; }
+
+        public bool IsAuthenticated => !string.IsNullOrWhiteSpace(AccessToken);
+
+        public event Action? SessionExpired;
+
         public async Task<bool> LoginAsync(string username, string password)
         {
             var payload = new { username, password };
-            var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-            var response = await _http.PostAsync("/api/auth/login", content);
+            var response = await SendAsync(HttpMethod.Post, "/api/auth/login", payload, requiresAuth: false);
+
             if (!response.IsSuccessStatusCode)
+            {
+                Logout();
                 return false;
+            }
 
+            var tokenResponse = await DeserializeAsync<TokenResponse>(response);
+            if (tokenResponse is null || string.IsNullOrWhiteSpace(tokenResponse.AccessToken) || string.IsNullOrWhiteSpace(tokenResponse.RefreshToken))
+            {
+                Logout();
+                return false;
+            }
+
+            AccessToken = tokenResponse.AccessToken;
+            RefreshToken = tokenResponse.RefreshToken;
+            ApplyAuthorizationHeader();
+            return true;
+        }
+
+        public void Logout()
+        {
+            AccessToken = null;
+            RefreshToken = null;
+            _http.DefaultRequestHeaders.Authorization = null;
+        }
+
+        public async Task<Player[]?> GetAllPlayersAsync()
+        {
+            var response = await SendWithAutoRefreshAsync(HttpMethod.Get, "/api/players");
+            if (!response.IsSuccessStatusCode)
+            {
+                return Array.Empty<Player>();
+            }
+
+            return await DeserializeAsync<Player[]>(response) ?? Array.Empty<Player>();
+        }
+
+        public async Task<Player?> GetPlayerByIdAsync(string recordId)
+        {
+            var response = await SendWithAutoRefreshAsync(HttpMethod.Get, $"/api/players/{Uri.EscapeDataString(recordId)}");
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            return await DeserializeAsync<Player>(response);
+        }
+
+        public async Task<Player?> CreatePlayerAsync(Player player)
+        {
+            var payload = new
+            {
+                name = player.Name,
+                team = player.Team,
+                season = player.Season,
+                points = player.Points
+            };
+            var response = await SendWithAutoRefreshAsync(HttpMethod.Post, "/api/players", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            return await DeserializeAsync<Player>(response);
+        }
+
+        public async Task<Player?> UpdatePlayerAsync(Player player)
+        {
+            if (string.IsNullOrWhiteSpace(player.Id))
+            {
+                throw new ArgumentException("Cannot update player without record id.", nameof(player));
+            }
+
+            var payload = new
+            {
+                name = player.Name,
+                team = player.Team,
+                season = player.Season,
+                points = player.Points
+            };
+            var response = await SendWithAutoRefreshAsync(HttpMethod.Patch, $"/api/players/{Uri.EscapeDataString(player.Id)}", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            return await DeserializeAsync<Player>(response);
+        }
+
+        public async Task<bool> DeletePlayerAsync(string recordId)
+        {
+            var response = await SendWithAutoRefreshAsync(HttpMethod.Delete, $"/api/players/{Uri.EscapeDataString(recordId)}");
+            return response.StatusCode == HttpStatusCode.NoContent || response.IsSuccessStatusCode;
+        }
+
+        private async Task<HttpResponseMessage> SendWithAutoRefreshAsync(HttpMethod method, string url, object? payload = null)
+        {
+            ApplyAuthorizationHeader();
+            var response = await SendAsync(method, url, payload);
+            if (response.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                return response;
+            }
+
+            var refreshed = await TryRefreshTokenAsync();
+            if (!refreshed)
+            {
+                Logout();
+                SessionExpired?.Invoke();
+                return response;
+            }
+
+            return await SendAsync(method, url, payload);
+        }
+
+        private async Task<bool> TryRefreshTokenAsync()
+        {
+            if (string.IsNullOrWhiteSpace(RefreshToken))
+            {
+                return false;
+            }
+
+            var refreshPayload = new { refreshToken = RefreshToken };
+            var response = await SendAsync(HttpMethod.Post, "/api/auth/refresh", refreshPayload, requiresAuth: false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return false;
+            }
+
+            var refreshedTokens = await DeserializeAsync<TokenResponse>(response);
+            if (refreshedTokens is null || string.IsNullOrWhiteSpace(refreshedTokens.AccessToken))
+            {
+                return false;
+            }
+
+            AccessToken = refreshedTokens.AccessToken;
+            RefreshToken = refreshedTokens.RefreshToken;
+            ApplyAuthorizationHeader();
+            return true;
+        }
+
+        private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string url, object? payload = null, bool requiresAuth = true)
+        {
+            using var request = new HttpRequestMessage(method, url);
+            if (payload is not null)
+            {
+                request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+            }
+
+            if (requiresAuth && !string.IsNullOrWhiteSpace(AccessToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            }
+
+            return await _http.SendAsync(request);
+        }
+
+        private async Task<T?> DeserializeAsync<T>(HttpResponseMessage response)
+        {
             var body = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return default;
+            }
 
-            // Try to detect if the response is JSON
-            if (!string.IsNullOrWhiteSpace(body) && (body.TrimStart().StartsWith("{") || body.TrimStart().StartsWith("[")))
-            {
-                try
-                {
-                    using var doc = JsonDocument.Parse(body);
-                    AccessToken = doc.RootElement.GetProperty("accessToken").GetString();
-                    RefreshToken = doc.RootElement.TryGetProperty("refreshToken", out var refresh) ? refresh.GetString() : null;
-                }
-                catch (JsonException)
-                {
-                    AccessToken = null;
-                    RefreshToken = null;
-                    return false;
-                }
-            }
-            else
-            {
-                // Treat as plain JWT string
-                AccessToken = body.Trim().Trim('"');
-                RefreshToken = null;
-            }
-            return !string.IsNullOrEmpty(AccessToken);
+            return JsonSerializer.Deserialize<T>(body, _jsonOptions);
         }
 
-        public void ApplyHeaders()
+        private void ApplyAuthorizationHeader()
         {
-            if (!string.IsNullOrEmpty(AccessToken))
-            {
-                _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
-            }
+            _http.DefaultRequestHeaders.Authorization = string.IsNullOrWhiteSpace(AccessToken)
+                ? null
+                : new AuthenticationHeaderValue("Bearer", AccessToken);
         }
 
-        public async Task<Models.Player?> GetPlayerByIdAsync(int id)
+        private class TokenResponse
         {
-            ApplyHeaders();
-            var response = await _http.GetAsync($"/api/players/{id}");
-            if (!response.IsSuccessStatusCode)
-                return null;
-
-            var xml = await response.Content.ReadAsStringAsync();
-            try
-            {
-                var doc = XDocument.Parse(xml);
-                var playerElement = doc.Descendants("Player").FirstOrDefault();
-                if (playerElement == null)
-                    return null;
-
-                return new Models.Player
-                {
-                    Id = (int?)playerElement.Element("id") ?? (int?)playerElement.Element("Id") ?? 0,
-                    Name = (string?)playerElement.Element("name") ?? (string?)playerElement.Element("Name"),
-                    Team = (string?)playerElement.Element("team") ?? (string?)playerElement.Element("Team"),
-                    Season = (string?)playerElement.Element("season") ?? (string?)playerElement.Element("Season"),
-                    Points = (double?)playerElement.Element("points") ?? (double?)playerElement.Element("Points") ?? 0
-                };
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        public async Task<Models.Player[]?> GetAllPlayersAsync()
-        {
-            ApplyHeaders();
-            var response = await _http.GetAsync("/api/players");
-            if (!response.IsSuccessStatusCode)
-                return Array.Empty<Models.Player>();
-
-            var xml = await response.Content.ReadAsStringAsync();
-            try
-            {
-                var doc = XDocument.Parse(xml);
-                var players = doc.Descendants("Player").Select(p => new Models.Player
-                {
-                    Id = (int?)p.Element("id") ?? (int?)p.Element("Id") ?? 0,
-                    Name = (string?)p.Element("name") ?? (string?)p.Element("Name"),
-                    Team = (string?)p.Element("team") ?? (string?)p.Element("Team"),
-                    Season = (string?)p.Element("season") ?? (string?)p.Element("Season"),
-                    Points = (double?)p.Element("points") ?? (double?)p.Element("Points") ?? 0
-                }).ToArray();
-                return players;
-            }
-            catch
-            {
-                return Array.Empty<Models.Player>();
-            }
-        }
-
-        public async Task<bool> CreatePlayerAsync(Models.Player player)
-        {
-            ApplyHeaders();
-            var content = new StringContent(JsonSerializer.Serialize(player), Encoding.UTF8, "application/json");
-            var response = await _http.PostAsync("/api/players", content);
-            return response.IsSuccessStatusCode;
-        }
-
-        public async Task<bool> UpdatePlayerAsync(Models.Player player)
-        {
-            ApplyHeaders();
-            var content = new StringContent(JsonSerializer.Serialize(player), Encoding.UTF8, "application/json");
-            var response = await _http.PutAsync($"/api/players/{player.Id}", content);
-            return response.IsSuccessStatusCode;
-        }
-
-        public async Task<bool> DeletePlayerAsync(int id)
-        {
-            ApplyHeaders();
-            var response = await _http.DeleteAsync($"/api/players/{id}");
-            return response.IsSuccessStatusCode;
+            public string? AccessToken { get; set; }
+            public string? RefreshToken { get; set; }
         }
     }
 }

--- a/IISApp/Services/AppConfig.cs
+++ b/IISApp/Services/AppConfig.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Configuration;
+
+namespace IISApp.Services
+{
+    public static class AppConfig
+    {
+        public static string ApiBaseUrl => ReadRequired("ApiBaseUrl", "http://localhost:8080");
+
+        public static string SoapBaseUrl => ReadRequired("SoapBaseUrl", ApiBaseUrl);
+
+        public static string WeatherServiceUrl => ReadRequired("WeatherServiceUrl", "http://localhost:9090/RPC2");
+
+        public static FrontendAccessMode AccessMode
+        {
+            get
+            {
+                var value = (ConfigurationManager.AppSettings["FrontendAccessMode"] ?? "FullAccess").Trim();
+                return value.Equals("ReadOnly", StringComparison.OrdinalIgnoreCase)
+                    ? FrontendAccessMode.ReadOnly
+                    : FrontendAccessMode.FullAccess;
+            }
+        }
+
+        private static string ReadRequired(string key, string fallback)
+        {
+            var value = ConfigurationManager.AppSettings[key];
+            return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+    }
+}

--- a/IISApp/Services/PermissionService.cs
+++ b/IISApp/Services/PermissionService.cs
@@ -1,0 +1,24 @@
+namespace IISApp.Services
+{
+    public enum FrontendAccessMode
+    {
+        ReadOnly,
+        FullAccess
+    }
+
+    public class PermissionService
+    {
+        public PermissionService(FrontendAccessMode mode)
+        {
+            Mode = mode;
+        }
+
+        public FrontendAccessMode Mode { get; }
+
+        public bool CanReadPlayers => true;
+
+        public bool CanMutatePlayers => Mode == FrontendAccessMode.FullAccess;
+
+        public static PermissionService FromConfiguration() => new(AppConfig.AccessMode);
+    }
+}

--- a/IISApp/Services/SoapService.cs
+++ b/IISApp/Services/SoapService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -19,62 +20,64 @@ namespace IISApp.Services
 
         public async Task<Player[]> SearchPlayersAsync(string searchTerm)
         {
-            string soapBody = $"""
-            <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:web="http://example.com/players">
-              <SOAP-ENV:Header/>
-              <SOAP-ENV:Body>
-                <web:SearchRequest>
-                  <web:SearchTerm>{searchTerm}</web:SearchTerm>
-                </web:SearchRequest>
-              </SOAP-ENV:Body>
-            </SOAP-ENV:Envelope>
-            """;
+            var safeTerm = SecurityElement.Escape(searchTerm) ?? string.Empty;
+            var soapBody = $"""
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pl="http://example.com/players">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <pl:SearchRequest>
+      <pl:SearchTerm>{safeTerm}</pl:SearchTerm>
+    </pl:SearchRequest>
+  </soapenv:Body>
+</soapenv:Envelope>
+""";
 
-            var content = new StringContent(soapBody, Encoding.UTF8, "text/xml");
-            var response = await _http.PostAsync("/ws/players", content);
+            using var content = new StringContent(soapBody, Encoding.UTF8, "text/xml");
+            content.Headers.Add("SOAPAction", "");
+
+            var response = await _http.PostAsync("/ws", content);
             var xml = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"SOAP request failed ({(int)response.StatusCode}): {xml}");
+            }
+
             return ParsePlayers(xml);
         }
 
-        private Player[] ParsePlayers(string xml)
+        private static Player[] ParsePlayers(string xml)
         {
-            var list = new List<Player>();
             var doc = new XmlDocument();
             doc.LoadXml(xml);
 
-            // Find all elements with local-name 'Player' regardless of namespace
-            var nodes = doc.SelectNodes("//*[local-name()='Player']");
-            if (nodes != null)
+            var faultNode = doc.SelectSingleNode("//*[local-name()='Fault']");
+            if (faultNode != null)
             {
-                foreach (XmlNode node in nodes)
-                {
-                    var player = new Player();
-                    foreach (XmlNode child in node.ChildNodes)
-                    {
-                        switch (child.LocalName.ToLower())
-                        {
-                            case "id":
-                                if (int.TryParse(child.InnerText, out var id))
-                                    player.Id = id;
-                                break;
-                            case "name":
-                                player.Name = child.InnerText;
-                                break;
-                            case "team":
-                                player.Team = child.InnerText;
-                                break;
-                            case "season":
-                                player.Season = child.InnerText;
-                                break;
-                            case "points":
-                                if (double.TryParse(child.InnerText, out var p))
-                                    player.Points = p;
-                                break;
-                        }
-                    }
-                    list.Add(player);
-                }
+                var faultText = faultNode.InnerText.Trim();
+                throw new InvalidOperationException(string.IsNullOrWhiteSpace(faultText) ? "SOAP fault received." : $"SOAP fault: {faultText}");
             }
+
+            var list = new List<Player>();
+            var nodes = doc.SelectNodes("//*[local-name()='SearchResponse']/*[local-name()='Player']");
+            if (nodes == null)
+            {
+                return Array.Empty<Player>();
+            }
+
+            foreach (XmlNode node in nodes)
+            {
+                var player = new Player
+                {
+                    Name = node.SelectSingleNode("./*[local-name()='name']")?.InnerText,
+                    Team = node.SelectSingleNode("./*[local-name()='team']")?.InnerText,
+                    Season = int.TryParse(node.SelectSingleNode("./*[local-name()='season']")?.InnerText, out var season) ? season : 0,
+                    Points = double.TryParse(node.SelectSingleNode("./*[local-name()='points']")?.InnerText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points) ? points : 0
+                };
+
+                list.Add(player);
+            }
+
             return list.ToArray();
         }
     }

--- a/IISApp/Services/ValidationService.cs
+++ b/IISApp/Services/ValidationService.cs
@@ -15,12 +15,12 @@ namespace IISApp.Services
 
         public async Task<string> ValidateAndSaveAsync(string xml, string schema)
         {
-            _api.ApplyHeaders();
-            var url = "/validateAndSaveXml";
-            var content = new StringContent(xml, Encoding.UTF8, "application/xml");
-            var response = await _api.HttpClient.PostAsync(url, content);
-            return await response.Content.ReadAsStringAsync();
+            // The current backend supports only validate+save via /validateAndSaveXml.
+            // Schema is left in the signature because the UI still lets the user choose for demo parity.
+            using var content = new StringContent(xml, Encoding.UTF8, "application/xml");
+            var response = await _api.HttpClient.PostAsync("/validateAndSaveXml", content);
+            var body = await response.Content.ReadAsStringAsync();
+            return response.IsSuccessStatusCode ? body : $"Validation/save failed ({(int)response.StatusCode}): {body}";
         }
     }
 }
-

--- a/IISApp/Services/WeatherServiceClient.cs
+++ b/IISApp/Services/WeatherServiceClient.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Net.Http;
+using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -12,87 +12,95 @@ namespace IISApp.Services
     {
         private readonly HttpClient _http;
 
-        public WeatherServiceClient(string baseUrl)
+        public WeatherServiceClient(string serviceUrl)
         {
-            _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
+            _http = new HttpClient { BaseAddress = new Uri(serviceUrl) };
         }
 
-        public async Task<Dictionary<string, double>> GetTemperaturesAsync(string city)
+        public async Task<IReadOnlyList<WeatherResult>> GetTemperaturesAsync(string city)
         {
-            string xmlRpcRequest = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+            var escapedCity = SecurityElement.Escape(city) ?? string.Empty;
+            var xmlRpcRequest = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
 <methodCall>
     <methodName>WeatherService.getTemperature</methodName>
     <params>
         <param>
-            <value><string>{System.Security.SecurityElement.Escape(city)}</string></value>
+            <value><string>{escapedCity}</string></value>
         </param>
     </params>
 </methodCall>";
 
-            try
+            using var content = new StringContent(xmlRpcRequest, new UTF8Encoding(false), "text/xml");
+            var response = await _http.PostAsync(string.Empty, content);
+            if (!response.IsSuccessStatusCode)
             {
-                var content = new StringContent(xmlRpcRequest, new UTF8Encoding(false), "text/xml");
-                var response = await _http.PostAsync("/xmlrpc", content);
-
-                if (!response.IsSuccessStatusCode)
-                    throw new HttpRequestException($"Server returned status code {response.StatusCode}");
-
-                var xml = await response.Content.ReadAsStringAsync();
-                Console.WriteLine($"XML Response: {xml}");
-                return ParseTemperatures(xml);
+                throw new HttpRequestException($"Weather service returned status {(int)response.StatusCode}.");
             }
-            catch (Exception ex)
-            {
-                // Log or handle as needed; for now, rethrow with context
-                throw new ApplicationException("Failed to get temperatures from XML-RPC service.", ex);
-            }
+
+            var xml = await response.Content.ReadAsStringAsync();
+            return ParseTemperatures(xml);
         }
 
-        private Dictionary<string, double> ParseTemperatures(string xml)
+        private List<WeatherResult> ParseTemperatures(string xml)
         {
-            var result = new Dictionary<string, double>();
-            try
+            var result = new List<WeatherResult>();
+            var doc = new XmlDocument();
+            doc.LoadXml(xml);
+
+            var valueNodes = doc.SelectNodes("/methodResponse/params/param/value/array/data/value");
+            if (valueNodes == null || valueNodes.Count == 0)
             {
-                var doc = new XmlDocument();
-                doc.LoadXml(xml);
+                return result;
+            }
 
-                // Try to parse struct nodes first
-                var structs = doc.SelectNodes("/methodResponse/params/param/value/array/data/value/struct | /methodResponse/params/param/value/struct");
-                if (structs != null && structs.Count > 0)
+            foreach (XmlNode valueNode in valueNodes)
+            {
+                var text = valueNode.InnerText.Trim();
+                if (string.IsNullOrWhiteSpace(text))
                 {
-                    foreach (XmlNode structNode in structs)
-                    {
-                        var cityNode = structNode.SelectSingleNode("member[name='city']/value | member[@name='city']/value");
-                        var tempNode = structNode.SelectSingleNode("member[name='temperature']/value | member[@name='temperature']/value");
-                        if (cityNode == null || tempNode == null)
-                            continue;
+                    continue;
+                }
 
-                        var cityName = cityNode.InnerText;
-                        if (double.TryParse(tempNode.InnerText, NumberStyles.Float, CultureInfo.InvariantCulture, out var temperature))
-                        {
-                            result[cityName] = temperature;
-                        }
-                    }
+                if (text.Contains(':'))
+                {
+                    var split = text.Split(':', 2, StringSplitOptions.TrimEntries);
+                    result.Add(new WeatherResult(split[0], split[1]));
+                }
+                else if (text.Equals("City not found", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(new WeatherResult(city: string.Empty, temperature: string.Empty, message: text));
                 }
                 else
                 {
-                    // Fallback: try to parse a single value
-                    var valueNode = doc.SelectSingleNode("/methodResponse/params/param/value");
-                    if (valueNode != null && double.TryParse(valueNode.InnerText, NumberStyles.Float, CultureInfo.InvariantCulture, out var temperature))
-                    {
-                        result["Unknown"] = temperature; // Use a default key if city is not provided
-                    }
+                    result.Add(new WeatherResult(city: string.Empty, temperature: string.Empty, message: text));
                 }
             }
-            catch (XmlException ex)
-            {
-                throw new ApplicationException("Failed to parse XML response.", ex);
-            }
-            catch (Exception ex)
-            {
-                throw new ApplicationException("Unexpected error while parsing temperatures.", ex);
-            }
+
             return result;
+        }
+    }
+
+    public class WeatherResult
+    {
+        public WeatherResult(string city, string temperature, string? message = null)
+        {
+            City = city;
+            Temperature = temperature;
+            Message = message;
+        }
+
+        public string City { get; }
+        public string Temperature { get; }
+        public string? Message { get; }
+
+        public override string ToString()
+        {
+            if (!string.IsNullOrWhiteSpace(Message))
+            {
+                return Message;
+            }
+
+            return $"{City}: {Temperature} °C";
         }
     }
 }

--- a/IISApp/ValidateAndSaveWindow.xaml
+++ b/IISApp/ValidateAndSaveWindow.xaml
@@ -40,7 +40,7 @@
                 <ComboBoxItem Content="XSD" IsSelected="True"/>
                 <ComboBoxItem Content="RNG"/>
             </ComboBox>
-            <Button x:Name="ValidateButton" Content="Validate" Margin="5" Click="ValidateButton_Click" />
+            <Button x:Name="ValidateButton" Content="Validate (uses save endpoint)" Margin="5" Click="ValidateButton_Click" />
             <Button x:Name="ValidateAndSaveButton" Content="Validate &amp; Save" Margin="5" Click="ValidateAndSaveButton_Click" />
         </StackPanel>
 

--- a/IISApp/ValidateAndSaveWindow.xaml.cs
+++ b/IISApp/ValidateAndSaveWindow.xaml.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Xml.Linq;
 using IISApp.Services;
 
 namespace IISApp
@@ -8,7 +10,7 @@ namespace IISApp
     {
         private readonly ValidationService _validator;
 
-        public ValidateAndSaveWindow() : this(new ApiService("http://localhost:8080"))
+        public ValidateAndSaveWindow() : this(new ApiService(AppConfig.ApiBaseUrl))
         {
         }
 
@@ -20,44 +22,46 @@ namespace IISApp
 
         private string BuildPlayerXml()
         {
-            var name = NameTextBox.Text;
-            var team = TeamTextBox.Text;
-            var season = SeasonTextBox.Text;
-            var points = PointsTextBox.Text;
+            var xml = new XElement("Players",
+                new XElement("Player",
+                    new XElement("name", NameTextBox.Text.Trim()),
+                    new XElement("team", TeamTextBox.Text.Trim()),
+                    new XElement("season", int.TryParse(SeasonTextBox.Text, out var season) ? season : 0),
+                    new XElement("points", double.TryParse(PointsTextBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var points) ? points.ToString(CultureInfo.InvariantCulture) : "0")));
 
-            return $"<Players><Player><name>{name}</name><team>{team}</team><season>{season}</season><points>{points}</points></Player></Players>";
+            return xml.ToString(SaveOptions.DisableFormatting);
         }
 
         private string GetSchema()
         {
             if (SchemaComboBox.SelectedItem is ComboBoxItem item)
+            {
                 return item.Content?.ToString()?.ToLowerInvariant() ?? "xsd";
+            }
+
             return "xsd";
         }
 
         private async void ValidateButton_Click(object sender, RoutedEventArgs e)
         {
-            var xml = BuildPlayerXml();
-            var schema = GetSchema();
-            try
-            {
-                var result = await _validator.ValidateAsync(xml, schema);
-                ResponseTextBox.Text = result;
-            }
-            catch (System.Exception ex)
-            {
-                ResponseTextBox.Text = $"Error: {ex.Message}";
-            }
+            // Backend currently exposes only validate+save (/validateAndSaveXml).
+            await ExecuteValidateAndSaveAsync("Validate (backend validates and saves)");
         }
 
         private async void ValidateAndSaveButton_Click(object sender, RoutedEventArgs e)
         {
+            await ExecuteValidateAndSaveAsync("Validate & Save");
+        }
+
+        private async System.Threading.Tasks.Task ExecuteValidateAndSaveAsync(string actionLabel)
+        {
             var xml = BuildPlayerXml();
             var schema = GetSchema();
+
             try
             {
                 var result = await _validator.ValidateAndSaveAsync(xml, schema);
-                ResponseTextBox.Text = result;
+                ResponseTextBox.Text = $"{actionLabel}:{System.Environment.NewLine}{result}";
             }
             catch (System.Exception ex)
             {
@@ -66,4 +70,3 @@ namespace IISApp
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- Make the WPF frontend consistent with the provided backend (JSON players API, string record ids, `PATCH` for updates, JWT login/refresh, SOAP at `/ws`, XML-RPC weather) while preserving the existing window + code-behind structure.
- Fix multiple runtime bugs (numeric id assumptions, XML vs JSON parsing, wrong HTTP verbs, missing validate-only endpoint) and make the app demo-ready with safer XML building and centralized configuration.
- Centralize auth/session handling (tokens and automatic refresh) and provide a simple, isolated frontend permission toggle for read-only vs full-access demos.

### Description
- Changed `Player` model id to `string?` and added JSON mapping; updated all CRUD flows to use string record ids and JSON payloads instead of XML/integers.
- Reworked `ApiService` to deserialize JSON, attach `Bearer` tokens centrally, perform one automatic refresh on 401 via `POST /api/auth/refresh`, and surface `SessionExpired` events; `PATCH` is used for updates and `POST` for create.
- Centralized endpoints and demo mode in `App.config` + `Services/AppConfig.cs`, added `PermissionService` to isolate read-only vs full-access behavior, and wired UI enable/disable logic accordingly.
- Fixed `PlayersWindow` (load, select, populate, create vs update, delete confirmation, logout), `ValidateAndSaveWindow` (explicitly uses backend `/validateAndSaveXml` and uses `XElement` for safe XML building), `SoapService` (posts to `/ws` with correct namespace and handles faults), and `WeatherServiceClient` (uses XML-RPC `/RPC2` style responses and formats results via `WeatherResult`).

### Testing
- Updated unit tests: `IISApp.Tests/WeatherServiceClientTests.cs` adjusted to the new XML-RPC parser expectations but tests were not executed here.
- Attempted to run `dotnet test IISApp.sln` in this environment but it failed because the `dotnet` CLI is not available, so automated tests could not be run (failure: `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed011b8af8832aa5702c1917c9745c)