### PR TITLE
Validate numeric user input before XML save

### DIFF
--- a/IISApp/ValidateAndSaveWindow.xaml.cs
+++ b/IISApp/ValidateAndSaveWindow.xaml.cs
@@ -26,8 +26,8 @@ namespace IISApp
                 new XElement("Player",
                     new XElement("name", NameTextBox.Text.Trim()),
                     new XElement("team", TeamTextBox.Text.Trim()),
-                    new XElement("season", int.TryParse(SeasonTextBox.Text, out var season) ? season : 0),
-                    new XElement("points", double.TryParse(PointsTextBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var points) ? points.ToString(CultureInfo.InvariantCulture) : "0")));
+                    new XElement("season", int.Parse(SeasonTextBox.Text.Trim(), CultureInfo.InvariantCulture)),
+                    new XElement("points", double.Parse(PointsTextBox.Text.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))));
 
             return xml.ToString(SaveOptions.DisableFormatting);
         }
@@ -55,6 +55,12 @@ namespace IISApp
 
         private async System.Threading.Tasks.Task ExecuteValidateAndSaveAsync(string actionLabel)
         {
+            if (!TryValidateInputs(out var validationError))
+            {
+                ResponseTextBox.Text = validationError;
+                return;
+            }
+
             var xml = BuildPlayerXml();
             var schema = GetSchema();
 
@@ -67,6 +73,30 @@ namespace IISApp
             {
                 ResponseTextBox.Text = $"Error: {ex.Message}";
             }
+        }
+
+        private bool TryValidateInputs(out string errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(NameTextBox.Text) || string.IsNullOrWhiteSpace(TeamTextBox.Text))
+            {
+                errorMessage = "User invalid: name and team are required.";
+                return false;
+            }
+
+            if (!int.TryParse(SeasonTextBox.Text.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+            {
+                errorMessage = "User invalid: season must be a valid integer.";
+                return false;
+            }
+
+            if (!double.TryParse(PointsTextBox.Text.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+            {
+                errorMessage = "User invalid: points must be a valid number.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent numeric fields from being silently converted to `0` when the user enters invalid numeric text. 
- Surface clear, client-side errors instead of sending invalid data to the backend. 
- Ensure required textual fields are present before attempting validation/save. 

### Description
- Added a `TryValidateInputs` method in `IISApp/ValidateAndSaveWindow.xaml.cs` that checks `name`/`team` presence and validates `season` (integer) and `points` (float) using `int.TryParse`/`double.TryParse`. 
- Wired the validation into `ExecuteValidateAndSaveAsync` to short-circuit and display a user-facing error in `ResponseTextBox` when validation fails. 
- Replaced previous `TryParse`-with-default logic in `BuildPlayerXml` with strict `int.Parse`/`double.Parse` so XML building uses already-validated numeric values. 
- Added explicit user error messages: `User invalid: name and team are required.`, `User invalid: season must be a valid integer.`, and `User invalid: points must be a valid number.`

### Testing
- Attempted to run `dotnet test IISApp.sln`, but the `dotnet` CLI is not installed in this environment so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1fbdb790832a973bda54e92e1506)