### PR TITLE
Forward schema to validation endpoint and enforce numeric player validation

### DIFF
--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -184,11 +184,41 @@ namespace IISApp
 
         private async void ValidateButton_Click(object sender, RoutedEventArgs e)
         {
+            if (!TryValidatePlayerForm(out var errorMessage))
+            {
+                MessageBox.Show(errorMessage, "Validation error", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             var player = BuildPlayerFromForm();
             var xml = BuildPlayerXml(player);
             var schema = GetSelectedSchema();
             var result = await _validator.ValidateAndSaveAsync(xml, schema);
             MessageBox.Show(result, "Validate & Save result");
+        }
+
+        private bool TryValidatePlayerForm(out string errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(NameTextBox.Text) || string.IsNullOrWhiteSpace(TeamTextBox.Text))
+            {
+                errorMessage = "Name and team are required.";
+                return false;
+            }
+
+            if (!int.TryParse(SeasonTextBox.Text.Trim(), out _))
+            {
+                errorMessage = "Season must be a valid integer.";
+                return false;
+            }
+
+            if (!double.TryParse(PointsTextBox.Text.Trim(), out _))
+            {
+                errorMessage = "Points must be a valid number.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
         }
 
         private async void PlayersListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/IISApp/Services/ValidationService.cs
+++ b/IISApp/Services/ValidationService.cs
@@ -15,10 +15,9 @@ namespace IISApp.Services
 
         public async Task<string> ValidateAndSaveAsync(string xml, string schema)
         {
-            // The current backend supports only validate+save via /validateAndSaveXml.
-            // Schema is left in the signature because the UI still lets the user choose for demo parity.
             using var content = new StringContent(xml, Encoding.UTF8, "application/xml");
-            var response = await _api.HttpClient.PostAsync("/validateAndSaveXml", content);
+            var requestUri = $"/validateAndSaveXml?schema={System.Uri.EscapeDataString(schema)}";
+            var response = await _api.HttpClient.PostAsync(requestUri, content);
             var body = await response.Content.ReadAsStringAsync();
             return response.IsSuccessStatusCode ? body : $"Validation/save failed ({(int)response.StatusCode}): {body}";
         }


### PR DESCRIPTION
### Motivation
- RNG selection in the UI was ignored by the backend call, causing responses to always reflect the default (XSD) behavior instead of the chosen schema.
- Player form submissions allowed non-numeric values for `season` and `points`, so invalid input could be sent to the backend and pass server-side validation incorrectly.
- A clearer client-side validation UX was needed to surface format errors before making the network request.

### Description
- Update `IISApp/Services/ValidationService.cs` to append the selected schema as a query parameter to the validation endpoint by constructing `requestUri = $"/validateAndSaveXml?schema={System.Uri.EscapeDataString(schema)}"` and posting to it.
- Add `TryValidatePlayerForm` to `IISApp/PlayersWindow.xaml.cs` to enforce that `name` and `team` are present, `season` parses as an integer, and `points` parses as a number, and call it from `ValidateButton_Click` to block submission on invalid input.
- Show a `MessageBox` with a descriptive validation warning when client-side validation fails, preventing the request from being sent.

### Testing
- Attempted to run `dotnet build IISApp.sln`, but the build could not be executed in this environment because `dotnet` is not installed (build not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfa70bf18832ab1a0eb226f441399)