### PR TITLE
Fix PlayersWindow input validation for season and points

### DIFF
--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Xml.Linq;
@@ -33,16 +34,67 @@ namespace IISApp
             AccessModeTextBlock.Text = isReadOnly ? "Mode: Read-only" : "Mode: Full-access";
         }
 
-        private Player BuildPlayerFromForm()
+        private bool TryBuildPlayerFromForm(out Player player, out string errorMessage)
         {
-            return new Player
+            player = new Player();
+
+            var name = NameTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                errorMessage = "Name is required.";
+                return false;
+            }
+
+            var team = TeamTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(team))
+            {
+                errorMessage = "Team is required.";
+                return false;
+            }
+
+            var seasonText = SeasonTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(seasonText))
+            {
+                errorMessage = "Season is required.";
+                return false;
+            }
+
+            if (!int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season))
+            {
+                errorMessage = "Season must be a valid integer.";
+                return false;
+            }
+
+            if (season <= 0)
+            {
+                errorMessage = "Season must be greater than 0.";
+                return false;
+            }
+
+            var pointsText = PointsTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(pointsText))
+            {
+                errorMessage = "Points is required.";
+                return false;
+            }
+
+            if (!double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points))
+            {
+                errorMessage = "Points must be a valid number.";
+                return false;
+            }
+
+            player = new Player
             {
                 Id = string.IsNullOrWhiteSpace(IdTextBox.Text) ? null : IdTextBox.Text.Trim(),
-                Name = NameTextBox.Text.Trim(),
-                Team = TeamTextBox.Text.Trim(),
-                Season = int.TryParse(SeasonTextBox.Text, out var season) ? season : 0,
-                Points = double.TryParse(PointsTextBox.Text, out var points) ? points : 0
+                Name = name,
+                Team = team,
+                Season = season,
+                Points = points
             };
+
+            errorMessage = string.Empty;
+            return true;
         }
 
         private void PopulateForm(Player player)
@@ -118,10 +170,9 @@ namespace IISApp
                 return;
             }
 
-            var player = BuildPlayerFromForm();
-            if (string.IsNullOrWhiteSpace(player.Name) || string.IsNullOrWhiteSpace(player.Team) || player.Season <= 0)
+            if (!TryBuildPlayerFromForm(out var player, out var validationError))
             {
-                MessageBox.Show("Name, team, and season are required.");
+                MessageBox.Show(validationError);
                 return;
             }
 
@@ -184,7 +235,12 @@ namespace IISApp
 
         private async void ValidateButton_Click(object sender, RoutedEventArgs e)
         {
-            var player = BuildPlayerFromForm();
+            if (!TryBuildPlayerFromForm(out var player, out var validationError))
+            {
+                MessageBox.Show(validationError);
+                return;
+            }
+
             var xml = BuildPlayerXml(player);
             var schema = GetSelectedSchema();
             var result = await _validator.ValidateAndSaveAsync(xml, schema);


### PR DESCRIPTION
### Motivation
- Prevent silent coercion of invalid numeric input (e.g., "abc" -> 0 for `Points`) so invalid data is not sent to the API.
- Ensure frontend enforces the same required-field and numeric parsing rules used elsewhere in the app before creating/updating or validating a player.
- Keep existing permission and create-vs-update behaviors intact while improving UX by showing clear errors when validation fails.

### Description
- Replaced permissive `BuildPlayerFromForm` with `TryBuildPlayerFromForm(out Player player, out string errorMessage)` which validates `Name`, `Team`, `Season`, and `Points` and parses numbers using `CultureInfo.InvariantCulture`.
- `TryBuildPlayerFromForm` enforces: `Name` required, `Team` required, `Season` required and integer (`> 0`), and `Points` required and numeric (no silent conversion to `0`).
- Updated `SaveButton_Click` and `ValidateButton_Click` to call `TryBuildPlayerFromForm` and immediately `MessageBox.Show` the validation error and return if validation fails, preventing API calls when inputs are invalid.
- Preserved existing behaviors including read-only permission checks, authentication checks, create-vs-update based on `Id` presence, and invariant-culture XML formatting in `BuildPlayerXml`.

### Testing
- Attempted to run an automated build with `dotnet build` but it could not run in this environment because the `dotnet` CLI is not installed (`dotnet: command not found`).
- No automated tests were executed in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd010a09bc832ab9921d1f17b6b310)