### PR TITLE
Handle backend validation errors for player create/update

### DIFF
--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -178,22 +178,34 @@ namespace IISApp
 
             try
             {
-                Player? result;
+                ApiResult<Player> result;
                 if (string.IsNullOrWhiteSpace(player.Id))
                 {
                     result = await _api.CreatePlayerAsync(player);
-                    MessageBox.Show(result is null ? "Create failed." : "Player created.");
+                    if (!result.Success)
+                    {
+                        MessageBox.Show(result.ErrorMessage, "Create failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
+                    MessageBox.Show("Player created.");
                 }
                 else
                 {
                     result = await _api.UpdatePlayerAsync(player);
-                    MessageBox.Show(result is null ? "Update failed." : "Player updated.");
+                    if (!result.Success)
+                    {
+                        MessageBox.Show(result.ErrorMessage, "Update failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
+                    MessageBox.Show("Player updated.");
                 }
 
                 await LoadPlayersAsync();
-                if (result is not null)
+                if (result.Data is not null)
                 {
-                    PopulateForm(result);
+                    PopulateForm(result.Data);
                 }
             }
             catch (Exception ex)

--- a/IISApp/Services/ApiResult.cs
+++ b/IISApp/Services/ApiResult.cs
@@ -1,0 +1,12 @@
+using System.Net;
+
+namespace IISApp.Services
+{
+    public class ApiResult<T>
+    {
+        public bool Success { get; set; }
+        public T? Data { get; set; }
+        public string ErrorMessage { get; set; } = string.Empty;
+        public HttpStatusCode StatusCode { get; set; }
+    }
+}

--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using IISApp.Models;
@@ -84,7 +85,7 @@ namespace IISApp.Services
             return await DeserializeAsync<Player>(response);
         }
 
-        public async Task<Player?> CreatePlayerAsync(Player player)
+        public async Task<ApiResult<Player>> CreatePlayerAsync(Player player)
         {
             var payload = new
             {
@@ -96,13 +97,23 @@ namespace IISApp.Services
             var response = await SendWithAutoRefreshAsync(HttpMethod.Post, "/api/players", payload);
             if (!response.IsSuccessStatusCode)
             {
-                return null;
+                return new ApiResult<Player>
+                {
+                    Success = false,
+                    StatusCode = response.StatusCode,
+                    ErrorMessage = await ReadErrorMessageAsync(response)
+                };
             }
 
-            return await DeserializeAsync<Player>(response);
+            return new ApiResult<Player>
+            {
+                Success = true,
+                StatusCode = response.StatusCode,
+                Data = await DeserializeAsync<Player>(response)
+            };
         }
 
-        public async Task<Player?> UpdatePlayerAsync(Player player)
+        public async Task<ApiResult<Player>> UpdatePlayerAsync(Player player)
         {
             if (string.IsNullOrWhiteSpace(player.Id))
             {
@@ -119,10 +130,20 @@ namespace IISApp.Services
             var response = await SendWithAutoRefreshAsync(HttpMethod.Patch, $"/api/players/{Uri.EscapeDataString(player.Id)}", payload);
             if (!response.IsSuccessStatusCode)
             {
-                return null;
+                return new ApiResult<Player>
+                {
+                    Success = false,
+                    StatusCode = response.StatusCode,
+                    ErrorMessage = await ReadErrorMessageAsync(response)
+                };
             }
 
-            return await DeserializeAsync<Player>(response);
+            return new ApiResult<Player>
+            {
+                Success = true,
+                StatusCode = response.StatusCode,
+                Data = await DeserializeAsync<Player>(response)
+            };
         }
 
         public async Task<bool> DeletePlayerAsync(string recordId)
@@ -191,6 +212,100 @@ namespace IISApp.Services
             }
 
             return await _http.SendAsync(request);
+        }
+
+
+        private async Task<string> ReadErrorMessageAsync(HttpResponseMessage response)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return $"Request failed with status code {(int)response.StatusCode} ({response.StatusCode}).";
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                var root = doc.RootElement;
+
+                foreach (var key in new[] { "message", "error", "detail" })
+                {
+                    if (root.ValueKind == JsonValueKind.Object &&
+                        root.TryGetProperty(key, out var simpleProp) &&
+                        simpleProp.ValueKind == JsonValueKind.String)
+                    {
+                        var value = simpleProp.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                        {
+                            return value;
+                        }
+                    }
+                }
+
+                if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("errors", out var errors))
+                {
+                    var errorMessage = ExtractFieldErrors(errors);
+                    if (!string.IsNullOrWhiteSpace(errorMessage))
+                    {
+                        return errorMessage;
+                    }
+                }
+
+                if (root.ValueKind == JsonValueKind.Object &&
+                    root.TryGetProperty("data", out var data) &&
+                    data.ValueKind == JsonValueKind.Object)
+                {
+                    var errorMessage = ExtractFieldErrors(data);
+                    if (!string.IsNullOrWhiteSpace(errorMessage))
+                    {
+                        return errorMessage;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                return body;
+            }
+
+            return body;
+        }
+
+        private static string? ExtractFieldErrors(JsonElement element)
+        {
+            var messages = new List<string>();
+
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.Value.ValueKind == JsonValueKind.String)
+                {
+                    var value = property.Value.GetString();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        messages.Add($"{property.Name}: {value}");
+                    }
+
+                    continue;
+                }
+
+                if (property.Value.ValueKind == JsonValueKind.Object)
+                {
+                    if (property.Value.TryGetProperty("message", out var messageProp) && messageProp.ValueKind == JsonValueKind.String)
+                    {
+                        var value = messageProp.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                        {
+                            messages.Add($"{property.Name}: {value}");
+                        }
+                    }
+                }
+            }
+
+            return messages.Count > 0 ? string.Join(Environment.NewLine, messages) : null;
         }
 
         private async Task<T?> DeserializeAsync<T>(HttpResponseMessage response)


### PR DESCRIPTION
### Motivation
- Backend validation responses were being discarded by the frontend, causing only generic "Create failed." / "Update failed." messages to be shown instead of helpful validation text.
- The UI should present backend-provided validation errors (including PocketBase-style and field-specific messages) so users can correct submitted player data.

### Description
- Added a generic API wrapper `ApiResult<T>` in `IISApp/Services/ApiResult.cs` containing `Success`, `Data`, `ErrorMessage`, and `StatusCode` properties.
- Updated `CreatePlayerAsync` and `UpdatePlayerAsync` in `IISApp/Services/ApiService.cs` to return `Task<ApiResult<Player>>` and to return parsed backend error messages on failure instead of `null`.
- Implemented `ReadErrorMessageAsync` and `ExtractFieldErrors` helpers in `ApiService` to parse response bodies for `message`, `error`, `detail`, `errors` objects, and PocketBase-style `data.<field>.message`, with fallbacks to raw body or a status-code message when appropriate.
- Updated `PlayersWindow.SaveButton_Click` in `IISApp/PlayersWindow.xaml.cs` to consume `ApiResult<Player>`, display `result.ErrorMessage` in an error `MessageBox` on failure, avoid reloading the player list after failed create/update, and preserve existing local validation and success behavior.

### Testing
- Attempted to run `dotnet build` in the environment but the `dotnet` CLI is not available, so a build could not be executed or validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bd3517a8832ab00e8219a9e59a4e)