### PR TITLE
Introduce ApiResult wrapper, enrich error parsing, and surface API errors in Players UI

### DIFF
--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -170,30 +170,51 @@ namespace IISApp
                 return;
             }
 
-            if (!TryBuildPlayerFromForm(out var player, out var validationError))
+            var seasonText = SeasonTextBox.Text.Trim();
+            var pointsText = PointsTextBox.Text.Trim();
+
+            _ = int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season);
+            _ = double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points);
+
+            var player = new Player
             {
-                MessageBox.Show(validationError);
-                return;
-            }
+                Id = string.IsNullOrWhiteSpace(IdTextBox.Text) ? null : IdTextBox.Text.Trim(),
+                Name = NameTextBox.Text.Trim(),
+                Team = TeamTextBox.Text.Trim(),
+                Season = season,
+                Points = points
+            };
 
             try
             {
-                Player? result;
+                ApiResult<Player> result;
                 if (string.IsNullOrWhiteSpace(player.Id))
                 {
                     result = await _api.CreatePlayerAsync(player);
-                    MessageBox.Show(result is null ? "Create failed." : "Player created.");
+                    if (!result.Success)
+                    {
+                        MessageBox.Show(result.ErrorMessage, "Create failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
+                    MessageBox.Show("Player created.");
                 }
                 else
                 {
                     result = await _api.UpdatePlayerAsync(player);
-                    MessageBox.Show(result is null ? "Update failed." : "Player updated.");
+                    if (!result.Success)
+                    {
+                        MessageBox.Show(result.ErrorMessage, "Update failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
+                    MessageBox.Show("Player updated.");
                 }
 
                 await LoadPlayersAsync();
-                if (result is not null)
+                if (result.Data is not null)
                 {
-                    PopulateForm(result);
+                    PopulateForm(result.Data);
                 }
             }
             catch (Exception ex)

--- a/IISApp/Services/ApiResult.cs
+++ b/IISApp/Services/ApiResult.cs
@@ -1,0 +1,12 @@
+using System.Net;
+
+namespace IISApp.Services
+{
+    public class ApiResult<T>
+    {
+        public bool Success { get; set; }
+        public T? Data { get; set; }
+        public string ErrorMessage { get; set; } = string.Empty;
+        public HttpStatusCode StatusCode { get; set; }
+    }
+}

--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using IISApp.Models;
@@ -84,7 +85,7 @@ namespace IISApp.Services
             return await DeserializeAsync<Player>(response);
         }
 
-        public async Task<Player?> CreatePlayerAsync(Player player)
+        public async Task<ApiResult<Player>> CreatePlayerAsync(Player player)
         {
             var payload = new
             {
@@ -96,13 +97,23 @@ namespace IISApp.Services
             var response = await SendWithAutoRefreshAsync(HttpMethod.Post, "/api/players", payload);
             if (!response.IsSuccessStatusCode)
             {
-                return null;
+                return new ApiResult<Player>
+                {
+                    Success = false,
+                    StatusCode = response.StatusCode,
+                    ErrorMessage = await ReadErrorMessageAsync(response)
+                };
             }
 
-            return await DeserializeAsync<Player>(response);
+            return new ApiResult<Player>
+            {
+                Success = true,
+                StatusCode = response.StatusCode,
+                Data = await DeserializeAsync<Player>(response)
+            };
         }
 
-        public async Task<Player?> UpdatePlayerAsync(Player player)
+        public async Task<ApiResult<Player>> UpdatePlayerAsync(Player player)
         {
             if (string.IsNullOrWhiteSpace(player.Id))
             {
@@ -119,10 +130,20 @@ namespace IISApp.Services
             var response = await SendWithAutoRefreshAsync(HttpMethod.Patch, $"/api/players/{Uri.EscapeDataString(player.Id)}", payload);
             if (!response.IsSuccessStatusCode)
             {
-                return null;
+                return new ApiResult<Player>
+                {
+                    Success = false,
+                    StatusCode = response.StatusCode,
+                    ErrorMessage = await ReadErrorMessageAsync(response)
+                };
             }
 
-            return await DeserializeAsync<Player>(response);
+            return new ApiResult<Player>
+            {
+                Success = true,
+                StatusCode = response.StatusCode,
+                Data = await DeserializeAsync<Player>(response)
+            };
         }
 
         public async Task<bool> DeletePlayerAsync(string recordId)
@@ -191,6 +212,100 @@ namespace IISApp.Services
             }
 
             return await _http.SendAsync(request);
+        }
+
+
+        private async Task<string> ReadErrorMessageAsync(HttpResponseMessage response)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return $"Request failed with status code {(int)response.StatusCode} ({response.StatusCode}).";
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                var root = doc.RootElement;
+
+                foreach (var key in new[] { "message", "error", "detail" })
+                {
+                    if (root.ValueKind == JsonValueKind.Object &&
+                        root.TryGetProperty(key, out var simpleProp) &&
+                        simpleProp.ValueKind == JsonValueKind.String)
+                    {
+                        var value = simpleProp.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                        {
+                            return value;
+                        }
+                    }
+                }
+
+                if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("errors", out var errors))
+                {
+                    var errorMessage = ExtractFieldErrors(errors);
+                    if (!string.IsNullOrWhiteSpace(errorMessage))
+                    {
+                        return errorMessage;
+                    }
+                }
+
+                if (root.ValueKind == JsonValueKind.Object &&
+                    root.TryGetProperty("data", out var data) &&
+                    data.ValueKind == JsonValueKind.Object)
+                {
+                    var errorMessage = ExtractFieldErrors(data);
+                    if (!string.IsNullOrWhiteSpace(errorMessage))
+                    {
+                        return errorMessage;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                return body;
+            }
+
+            return body;
+        }
+
+        private static string? ExtractFieldErrors(JsonElement element)
+        {
+            var messages = new List<string>();
+
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.Value.ValueKind == JsonValueKind.String)
+                {
+                    var value = property.Value.GetString();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        messages.Add($"{property.Name}: {value}");
+                    }
+
+                    continue;
+                }
+
+                if (property.Value.ValueKind == JsonValueKind.Object)
+                {
+                    if (property.Value.TryGetProperty("message", out var messageProp) && messageProp.ValueKind == JsonValueKind.String)
+                    {
+                        var value = messageProp.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                        {
+                            messages.Add($"{property.Name}: {value}");
+                        }
+                    }
+                }
+            }
+
+            return messages.Count > 0 ? string.Join(Environment.NewLine, messages) : null;
         }
 
         private async Task<T?> DeserializeAsync<T>(HttpResponseMessage response)


### PR DESCRIPTION
### Motivation
- Improve error handling for create/update player API calls by returning structured results and displaying meaningful messages in the UI.
- Simplify form handling in the players window by parsing numeric inputs consistently and ensuring UI is updated with validated API responses.

### Description
- Added `IISApp.Services.ApiResult<T>` to represent success, data, error message, and HTTP status code for API calls (`ApiResult.cs`).
- Changed `CreatePlayerAsync` and `UpdatePlayerAsync` in `IISApp.Services.ApiService` to return `ApiResult<Player>` and populate `Success`, `Data`, `StatusCode`, and `ErrorMessage` based on the HTTP response (`ApiService.cs`).
- Implemented `ReadErrorMessageAsync` and `ExtractFieldErrors` in `ApiService` to parse JSON error bodies and prefer `message`, `error`, `detail`, `errors`, or field-specific messages for user-facing text (`ApiService.cs`).
- Updated `PlayersWindow.xaml.cs` to build a `Player` object directly from form fields with invariant culture parsing for `Season` and `Points`, to handle `ApiResult` responses by showing error dialogs when `Success` is false, and to populate the form with `result.Data` on success (`PlayersWindow.xaml.cs`).

### Testing
- Built the solution with `dotnet build` and the build completed successfully.
- Ran the automated unit/integration test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bd3517a8832ab00e8219a9e59a4e)