### PR TITLE
Return ApiResult<T> from ApiService and surface server errors in PlayersWindow

### DIFF
--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -34,69 +34,6 @@ namespace IISApp
             AccessModeTextBlock.Text = isReadOnly ? "Mode: Read-only" : "Mode: Full-access";
         }
 
-        private bool TryBuildPlayerFromForm(out Player player, out string errorMessage)
-        {
-            player = new Player();
-
-            var name = NameTextBox.Text.Trim();
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                errorMessage = "Name is required.";
-                return false;
-            }
-
-            var team = TeamTextBox.Text.Trim();
-            if (string.IsNullOrWhiteSpace(team))
-            {
-                errorMessage = "Team is required.";
-                return false;
-            }
-
-            var seasonText = SeasonTextBox.Text.Trim();
-            if (string.IsNullOrWhiteSpace(seasonText))
-            {
-                errorMessage = "Season is required.";
-                return false;
-            }
-
-            if (!int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season))
-            {
-                errorMessage = "Season must be a valid integer.";
-                return false;
-            }
-
-            if (season <= 0)
-            {
-                errorMessage = "Season must be greater than 0.";
-                return false;
-            }
-
-            var pointsText = PointsTextBox.Text.Trim();
-            if (string.IsNullOrWhiteSpace(pointsText))
-            {
-                errorMessage = "Points is required.";
-                return false;
-            }
-
-            if (!double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points))
-            {
-                errorMessage = "Points must be a valid number.";
-                return false;
-            }
-
-            player = new Player
-            {
-                Id = string.IsNullOrWhiteSpace(IdTextBox.Text) ? null : IdTextBox.Text.Trim(),
-                Name = name,
-                Team = team,
-                Season = season,
-                Points = points
-            };
-
-            errorMessage = string.Empty;
-            return true;
-        }
-
         private void PopulateForm(Player player)
         {
             IdTextBox.Text = player.Id ?? string.Empty;
@@ -170,30 +107,51 @@ namespace IISApp
                 return;
             }
 
-            if (!TryBuildPlayerFromForm(out var player, out var validationError))
+            var seasonText = SeasonTextBox.Text.Trim();
+            var pointsText = PointsTextBox.Text.Trim();
+
+            _ = int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season);
+            _ = double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points);
+
+            var player = new Player
             {
-                MessageBox.Show(validationError);
-                return;
-            }
+                Id = string.IsNullOrWhiteSpace(IdTextBox.Text) ? null : IdTextBox.Text.Trim(),
+                Name = NameTextBox.Text.Trim(),
+                Team = TeamTextBox.Text.Trim(),
+                Season = season,
+                Points = points
+            };
 
             try
             {
-                Player? result;
+                ApiResult<Player> result;
                 if (string.IsNullOrWhiteSpace(player.Id))
                 {
                     result = await _api.CreatePlayerAsync(player);
-                    MessageBox.Show(result is null ? "Create failed." : "Player created.");
+                    if (!result.Success)
+                    {
+                        MessageBox.Show(result.ErrorMessage, "Create failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
+                    MessageBox.Show("Player created.");
                 }
                 else
                 {
                     result = await _api.UpdatePlayerAsync(player);
-                    MessageBox.Show(result is null ? "Update failed." : "Player updated.");
+                    if (!result.Success)
+                    {
+                        MessageBox.Show(result.ErrorMessage, "Update failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
+                    MessageBox.Show("Player updated.");
                 }
 
                 await LoadPlayersAsync();
-                if (result is not null)
+                if (result.Data is not null)
                 {
-                    PopulateForm(result);
+                    PopulateForm(result.Data);
                 }
             }
             catch (Exception ex)
@@ -235,11 +193,20 @@ namespace IISApp
 
         private async void ValidateButton_Click(object sender, RoutedEventArgs e)
         {
-            if (!TryBuildPlayerFromForm(out var player, out var validationError))
+            var seasonText = SeasonTextBox.Text.Trim();
+            var pointsText = PointsTextBox.Text.Trim();
+
+            _ = int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season);
+            _ = double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points);
+
+            var player = new Player
             {
-                MessageBox.Show(validationError);
-                return;
-            }
+                Id = string.IsNullOrWhiteSpace(IdTextBox.Text) ? null : IdTextBox.Text.Trim(),
+                Name = NameTextBox.Text.Trim(),
+                Team = TeamTextBox.Text.Trim(),
+                Season = season,
+                Points = points
+            };
 
             var xml = BuildPlayerXml(player);
             var schema = GetSelectedSchema();

--- a/IISApp/Services/ApiResult.cs
+++ b/IISApp/Services/ApiResult.cs
@@ -1,0 +1,12 @@
+using System.Net;
+
+namespace IISApp.Services
+{
+    public class ApiResult<T>
+    {
+        public bool Success { get; set; }
+        public T? Data { get; set; }
+        public string ErrorMessage { get; set; } = string.Empty;
+        public HttpStatusCode StatusCode { get; set; }
+    }
+}

--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using IISApp.Models;
@@ -84,7 +85,7 @@ namespace IISApp.Services
             return await DeserializeAsync<Player>(response);
         }
 
-        public async Task<Player?> CreatePlayerAsync(Player player)
+        public async Task<ApiResult<Player>> CreatePlayerAsync(Player player)
         {
             var payload = new
             {
@@ -96,13 +97,23 @@ namespace IISApp.Services
             var response = await SendWithAutoRefreshAsync(HttpMethod.Post, "/api/players", payload);
             if (!response.IsSuccessStatusCode)
             {
-                return null;
+                return new ApiResult<Player>
+                {
+                    Success = false,
+                    StatusCode = response.StatusCode,
+                    ErrorMessage = await ReadErrorMessageAsync(response)
+                };
             }
 
-            return await DeserializeAsync<Player>(response);
+            return new ApiResult<Player>
+            {
+                Success = true,
+                StatusCode = response.StatusCode,
+                Data = await DeserializeAsync<Player>(response)
+            };
         }
 
-        public async Task<Player?> UpdatePlayerAsync(Player player)
+        public async Task<ApiResult<Player>> UpdatePlayerAsync(Player player)
         {
             if (string.IsNullOrWhiteSpace(player.Id))
             {
@@ -119,10 +130,20 @@ namespace IISApp.Services
             var response = await SendWithAutoRefreshAsync(HttpMethod.Patch, $"/api/players/{Uri.EscapeDataString(player.Id)}", payload);
             if (!response.IsSuccessStatusCode)
             {
-                return null;
+                return new ApiResult<Player>
+                {
+                    Success = false,
+                    StatusCode = response.StatusCode,
+                    ErrorMessage = await ReadErrorMessageAsync(response)
+                };
             }
 
-            return await DeserializeAsync<Player>(response);
+            return new ApiResult<Player>
+            {
+                Success = true,
+                StatusCode = response.StatusCode,
+                Data = await DeserializeAsync<Player>(response)
+            };
         }
 
         public async Task<bool> DeletePlayerAsync(string recordId)
@@ -191,6 +212,100 @@ namespace IISApp.Services
             }
 
             return await _http.SendAsync(request);
+        }
+
+
+        private async Task<string> ReadErrorMessageAsync(HttpResponseMessage response)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return $"Request failed with status code {(int)response.StatusCode} ({response.StatusCode}).";
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                var root = doc.RootElement;
+
+                foreach (var key in new[] { "message", "error", "detail" })
+                {
+                    if (root.ValueKind == JsonValueKind.Object &&
+                        root.TryGetProperty(key, out var simpleProp) &&
+                        simpleProp.ValueKind == JsonValueKind.String)
+                    {
+                        var value = simpleProp.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                        {
+                            return value;
+                        }
+                    }
+                }
+
+                if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("errors", out var errors))
+                {
+                    var errorMessage = ExtractFieldErrors(errors);
+                    if (!string.IsNullOrWhiteSpace(errorMessage))
+                    {
+                        return errorMessage;
+                    }
+                }
+
+                if (root.ValueKind == JsonValueKind.Object &&
+                    root.TryGetProperty("data", out var data) &&
+                    data.ValueKind == JsonValueKind.Object)
+                {
+                    var errorMessage = ExtractFieldErrors(data);
+                    if (!string.IsNullOrWhiteSpace(errorMessage))
+                    {
+                        return errorMessage;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                return body;
+            }
+
+            return body;
+        }
+
+        private static string? ExtractFieldErrors(JsonElement element)
+        {
+            var messages = new List<string>();
+
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.Value.ValueKind == JsonValueKind.String)
+                {
+                    var value = property.Value.GetString();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        messages.Add($"{property.Name}: {value}");
+                    }
+
+                    continue;
+                }
+
+                if (property.Value.ValueKind == JsonValueKind.Object)
+                {
+                    if (property.Value.TryGetProperty("message", out var messageProp) && messageProp.ValueKind == JsonValueKind.String)
+                    {
+                        var value = messageProp.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                        {
+                            messages.Add($"{property.Name}: {value}");
+                        }
+                    }
+                }
+            }
+
+            return messages.Count > 0 ? string.Join(Environment.NewLine, messages) : null;
         }
 
         private async Task<T?> DeserializeAsync<T>(HttpResponseMessage response)


### PR DESCRIPTION
### Motivation
- Standardize API responses with a wrapper type and surface detailed server-side error messages to the UI when create/update operations fail.
- Simplify client-side form parsing and rely on API validation feedback instead of duplicating validation logic in the window code.

### Description
- Added a new generic `ApiResult<T>` type to represent success, data, error message, and status code for API calls.
- Changed `ApiService.CreatePlayerAsync` and `ApiService.UpdatePlayerAsync` to return `ApiResult<Player>` and implemented `ReadErrorMessageAsync` with `ExtractFieldErrors` to parse common error shapes from JSON responses.
- Updated `PlayersWindow.xaml.cs` to remove `TryBuildPlayerFromForm`, inline parsing of `Season` and `Points`, construct `Player` directly, and handle `ApiResult` responses by showing server error messages via `MessageBox` and populating the form from `result.Data` when available.
- Minor HTTP/send helpers adjusted to support the new error-reading behavior and added `using System.Collections.Generic` for error aggregation.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bd3517a8832ab00e8219a9e59a4e)