### PR TITLE
Preserve raw Season/Points on save and surface backend validation messages

### DIFF
--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Xml.Linq;
@@ -53,14 +52,14 @@ namespace IISApp
             PlayersListBox.SelectedItem = null;
         }
 
-        private string BuildPlayerXml(Player player)
+        private string BuildPlayerXml(string name, string team, string seasonText, string pointsText)
         {
             var xml = new XElement("Players",
                 new XElement("Player",
-                    new XElement("name", player.Name ?? string.Empty),
-                    new XElement("team", player.Team ?? string.Empty),
-                    new XElement("season", player.Season),
-                    new XElement("points", player.Points.ToString(System.Globalization.CultureInfo.InvariantCulture))));
+                    new XElement("name", name),
+                    new XElement("team", team),
+                    new XElement("season", seasonText),
+                    new XElement("points", pointsText)));
 
             return xml.ToString(SaveOptions.DisableFormatting);
         }
@@ -107,30 +106,21 @@ namespace IISApp
                 return;
             }
 
+            var id = IdTextBox.Text.Trim();
+            var name = NameTextBox.Text.Trim();
+            var team = TeamTextBox.Text.Trim();
             var seasonText = SeasonTextBox.Text.Trim();
             var pointsText = PointsTextBox.Text.Trim();
-
-            _ = int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season);
-            _ = double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points);
-
-            var player = new Player
-            {
-                Id = string.IsNullOrWhiteSpace(IdTextBox.Text) ? null : IdTextBox.Text.Trim(),
-                Name = NameTextBox.Text.Trim(),
-                Team = TeamTextBox.Text.Trim(),
-                Season = season,
-                Points = points
-            };
 
             try
             {
                 ApiResult<Player> result;
-                if (string.IsNullOrWhiteSpace(player.Id))
+                if (string.IsNullOrWhiteSpace(id))
                 {
-                    result = await _api.CreatePlayerAsync(player);
+                    result = await _api.CreatePlayerFromRawAsync(name, team, seasonText, pointsText);
                     if (!result.Success)
                     {
-                        MessageBox.Show(result.ErrorMessage, "Create failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(result.ErrorMessage, "Player validation failed", MessageBoxButton.OK, MessageBoxImage.Error);
                         return;
                     }
 
@@ -138,10 +128,10 @@ namespace IISApp
                 }
                 else
                 {
-                    result = await _api.UpdatePlayerAsync(player);
+                    result = await _api.UpdatePlayerFromRawAsync(id, name, team, seasonText, pointsText);
                     if (!result.Success)
                     {
-                        MessageBox.Show(result.ErrorMessage, "Update failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(result.ErrorMessage, "Player validation failed", MessageBoxButton.OK, MessageBoxImage.Error);
                         return;
                     }
 
@@ -193,22 +183,11 @@ namespace IISApp
 
         private async void ValidateButton_Click(object sender, RoutedEventArgs e)
         {
+            var name = NameTextBox.Text.Trim();
+            var team = TeamTextBox.Text.Trim();
             var seasonText = SeasonTextBox.Text.Trim();
             var pointsText = PointsTextBox.Text.Trim();
-
-            _ = int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season);
-            _ = double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points);
-
-            var player = new Player
-            {
-                Id = string.IsNullOrWhiteSpace(IdTextBox.Text) ? null : IdTextBox.Text.Trim(),
-                Name = NameTextBox.Text.Trim(),
-                Team = TeamTextBox.Text.Trim(),
-                Season = season,
-                Points = points
-            };
-
-            var xml = BuildPlayerXml(player);
+            var xml = BuildPlayerXml(name, team, seasonText, pointsText);
             var schema = GetSelectedSchema();
             var result = await _validator.ValidateAndSaveAsync(xml, schema);
             MessageBox.Show(result, "Validate & Save result");

--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Globalization;
 using System.Threading.Tasks;
 using IISApp.Models;
 
@@ -113,6 +114,28 @@ namespace IISApp.Services
             };
         }
 
+        public async Task<ApiResult<Player>> CreatePlayerFromRawAsync(string name, string team, string seasonText, string pointsText)
+        {
+            var payload = BuildRawPlayerPayload(name, team, seasonText, pointsText);
+            var response = await SendWithAutoRefreshAsync(HttpMethod.Post, "/api/players", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new ApiResult<Player>
+                {
+                    Success = false,
+                    StatusCode = response.StatusCode,
+                    ErrorMessage = await ReadErrorMessageAsync(response)
+                };
+            }
+
+            return new ApiResult<Player>
+            {
+                Success = true,
+                StatusCode = response.StatusCode,
+                Data = await DeserializeAsync<Player>(response)
+            };
+        }
+
         public async Task<ApiResult<Player>> UpdatePlayerAsync(Player player)
         {
             if (string.IsNullOrWhiteSpace(player.Id))
@@ -128,6 +151,33 @@ namespace IISApp.Services
                 points = player.Points
             };
             var response = await SendWithAutoRefreshAsync(HttpMethod.Patch, $"/api/players/{Uri.EscapeDataString(player.Id)}", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new ApiResult<Player>
+                {
+                    Success = false,
+                    StatusCode = response.StatusCode,
+                    ErrorMessage = await ReadErrorMessageAsync(response)
+                };
+            }
+
+            return new ApiResult<Player>
+            {
+                Success = true,
+                StatusCode = response.StatusCode,
+                Data = await DeserializeAsync<Player>(response)
+            };
+        }
+
+        public async Task<ApiResult<Player>> UpdatePlayerFromRawAsync(string id, string name, string team, string seasonText, string pointsText)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("Cannot update player without record id.", nameof(id));
+            }
+
+            var payload = BuildRawPlayerPayload(name, team, seasonText, pointsText);
+            var response = await SendWithAutoRefreshAsync(HttpMethod.Patch, $"/api/players/{Uri.EscapeDataString(id)}", payload);
             if (!response.IsSuccessStatusCode)
             {
                 return new ApiResult<Player>
@@ -228,6 +278,7 @@ namespace IISApp.Services
                 using var doc = JsonDocument.Parse(body);
                 var root = doc.RootElement;
 
+                string? generalMessage = null;
                 foreach (var key in new[] { "message", "error", "detail" })
                 {
                     if (root.ValueKind == JsonValueKind.Object &&
@@ -237,17 +288,19 @@ namespace IISApp.Services
                         var value = simpleProp.GetString();
                         if (!string.IsNullOrWhiteSpace(value))
                         {
-                            return value;
+                            generalMessage = value;
+                            break;
                         }
                     }
                 }
 
+                var fieldMessages = new List<string>();
                 if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("errors", out var errors))
                 {
                     var errorMessage = ExtractFieldErrors(errors);
                     if (!string.IsNullOrWhiteSpace(errorMessage))
                     {
-                        return errorMessage;
+                        fieldMessages.Add(errorMessage);
                     }
                 }
 
@@ -258,8 +311,23 @@ namespace IISApp.Services
                     var errorMessage = ExtractFieldErrors(data);
                     if (!string.IsNullOrWhiteSpace(errorMessage))
                     {
-                        return errorMessage;
+                        fieldMessages.Add(errorMessage);
                     }
+                }
+
+                if (!string.IsNullOrWhiteSpace(generalMessage) && fieldMessages.Count > 0)
+                {
+                    return $"{generalMessage}{Environment.NewLine}{string.Join(Environment.NewLine, fieldMessages)}";
+                }
+
+                if (!string.IsNullOrWhiteSpace(generalMessage))
+                {
+                    return generalMessage;
+                }
+
+                if (fieldMessages.Count > 0)
+                {
+                    return string.Join(Environment.NewLine, fieldMessages);
                 }
             }
             catch (JsonException)
@@ -268,6 +336,21 @@ namespace IISApp.Services
             }
 
             return body;
+        }
+
+        private static Dictionary<string, object> BuildRawPlayerPayload(string name, string team, string seasonText, string pointsText)
+        {
+            return new Dictionary<string, object>
+            {
+                ["name"] = name,
+                ["team"] = team,
+                ["season"] = int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season)
+                    ? season
+                    : seasonText,
+                ["points"] = double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points)
+                    ? points
+                    : pointsText
+            };
         }
 
         private static string? ExtractFieldErrors(JsonElement element)


### PR DESCRIPTION
### Motivation
- The UI previously parsed `Season` and `Points` before sending create/update requests, converting invalid input (e.g. `"abc"`) to numeric defaults and preventing the backend from returning proper validation messages. 
- The goal is to send the original textbox values to the API so server-side validation can report accurate errors, and to display those errors in the WPF UI.

### Description
- Stop client-side parsing in the save/validate flows by reading raw textbox values in `SaveButton_Click` and `ValidateButton_Click` and by building validation XML from raw strings via `BuildPlayerXml(string name, string team, string seasonText, string pointsText)` in `PlayersWindow.xaml.cs`.
- Add `CreatePlayerFromRawAsync(...)` and `UpdatePlayerFromRawAsync(...)` to `IISApp/Services/ApiService.cs` and implement `BuildRawPlayerPayload(...)` which sends `season`/`points` as numbers only when `int.TryParse`/`double.TryParse` (InvariantCulture) succeed, otherwise sends the original strings.
- Improve `ReadErrorMessageAsync(...)` to combine top-level messages (`message`/`error`/`detail`) with field-level errors from both `errors` and PocketBase-style `data` objects so the UI shows detailed backend validation text.
- Update the UI to show backend error text in a message box titled `Player validation failed` on API failures and to only reload/repopulate after successful responses.

### Testing
- Attempted an automated `dotnet build`, but it failed in this environment because the `dotnet` CLI is not available (`/bin/bash: line 1: dotnet: command not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cd6f7730832aa0fc9409297e6e53)