### PR TITLE
Improve frontend formatting for backend validation/save errors

### DIFF
--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -273,13 +273,84 @@ namespace IISApp.Services
                 return $"Request failed with status code {(int)response.StatusCode} ({response.StatusCode}).";
             }
 
+            return FormatErrorMessage(body);
+        }
+
+        public static string FormatErrorMessage(string rawError)
+        {
+            if (string.IsNullOrWhiteSpace(rawError))
+            {
+                return rawError;
+            }
+
+            var trimmedError = rawError.Trim();
+            var jsonStartIndex = trimmedError.IndexOf('{');
+            var prefix = string.Empty;
+            var jsonCandidate = trimmedError;
+
+            if (jsonStartIndex > 0)
+            {
+                prefix = trimmedError[..jsonStartIndex].Trim().TrimEnd(':');
+                var markerIndex = prefix.IndexOf(" (", StringComparison.Ordinal);
+                if (markerIndex > 0)
+                {
+                    prefix = prefix[..markerIndex];
+                }
+
+                if (!prefix.EndsWith(".", StringComparison.Ordinal))
+                {
+                    prefix = $"{prefix}.";
+                }
+
+                jsonCandidate = trimmedError[jsonStartIndex..];
+            }
+
             try
             {
-                using var doc = JsonDocument.Parse(body);
+                using var doc = JsonDocument.Parse(jsonCandidate);
                 var root = doc.RootElement;
 
+                var lines = new List<string>();
+                if (!string.IsNullOrWhiteSpace(prefix))
+                {
+                    lines.Add(prefix);
+                }
+
+                if (root.ValueKind == JsonValueKind.Object &&
+                    root.TryGetProperty("status", out var statusProp) &&
+                    (statusProp.ValueKind == JsonValueKind.Number || statusProp.ValueKind == JsonValueKind.String))
+                {
+                    var statusValue = statusProp.ToString();
+                    if (!string.IsNullOrWhiteSpace(statusValue))
+                    {
+                        lines.Add($"Status: {statusValue}");
+                    }
+                }
+
+                if (root.ValueKind == JsonValueKind.Object &&
+                    root.TryGetProperty("error", out var errorProp) &&
+                    errorProp.ValueKind == JsonValueKind.String)
+                {
+                    var errorValue = errorProp.GetString();
+                    if (!string.IsNullOrWhiteSpace(errorValue))
+                    {
+                        lines.Add($"Error: {errorValue}");
+                    }
+                }
+
+                if (root.ValueKind == JsonValueKind.Object &&
+                    root.TryGetProperty("path", out var pathProp) &&
+                    pathProp.ValueKind == JsonValueKind.String)
+                {
+                    var pathValue = pathProp.GetString();
+                    if (!string.IsNullOrWhiteSpace(pathValue))
+                    {
+                        lines.Add($"Path: {pathValue}");
+                    }
+                }
+
                 string? generalMessage = null;
-                foreach (var key in new[] { "message", "error", "detail" })
+                foreach (var key in new[] { "message", "detail" })
                 {
                     if (root.ValueKind == JsonValueKind.Object &&
                         root.TryGetProperty(key, out var simpleProp) &&
@@ -320,6 +391,23 @@ namespace IISApp.Services
                     return $"{generalMessage}{Environment.NewLine}{string.Join(Environment.NewLine, fieldMessages)}";
                 }
 
+                if (!string.IsNullOrWhiteSpace(generalMessage) && lines.Count > 0)
+                {
+                    lines.Insert(0, generalMessage);
+                    return string.Join(Environment.NewLine, lines);
+                }
+
+                if (fieldMessages.Count > 0 && lines.Count > 0)
+                {
+                    lines.Add(string.Join(Environment.NewLine, fieldMessages));
+                    return string.Join(Environment.NewLine, lines);
+                }
+
+                if (lines.Count > 0)
+                {
+                    return string.Join(Environment.NewLine, lines);
+                }
+
                 if (!string.IsNullOrWhiteSpace(generalMessage))
                 {
                     return generalMessage;
@@ -332,10 +420,10 @@ namespace IISApp.Services
             }
             catch (JsonException)
             {
-                return body;
+                return rawError;
             }
 
-            return body;
+            return rawError;
         }
 
         private static Dictionary<string, object> BuildRawPlayerPayload(string name, string team, string seasonText, string pointsText)

--- a/IISApp/Services/ValidationService.cs
+++ b/IISApp/Services/ValidationService.cs
@@ -20,7 +20,9 @@ namespace IISApp.Services
             using var content = new StringContent(xml, Encoding.UTF8, "application/xml");
             var response = await _api.HttpClient.PostAsync("/validateAndSaveXml", content);
             var body = await response.Content.ReadAsStringAsync();
-            return response.IsSuccessStatusCode ? body : $"Validation/save failed ({(int)response.StatusCode}): {body}";
+            return response.IsSuccessStatusCode
+                ? body
+                : ApiService.FormatErrorMessage($"Validation/save failed ({(int)response.StatusCode}): {body}");
         }
     }
 }


### PR DESCRIPTION
### Motivation
- The UI currently displays raw backend JSON error payloads which are hard for users to read. 
- The goal is to parse common backend error formats and present a concise, user-friendly message instead of raw JSON. 
- The change should not alter request, authentication, or player save/update behavior.

### Description
- Added a reusable helper `ApiService.FormatErrorMessage(string)` that parses raw error text (including prefixed text before JSON) and returns a readable message. 
- Updated `ApiService.ReadErrorMessageAsync` to call `FormatErrorMessage` when an error body is present. 
- Updated `ValidationService.ValidateAndSaveAsync` to run `/validateAndSaveXml` failures through `ApiService.FormatErrorMessage` before returning the result. 
- The formatter supports Spring Boot default errors (`status`, `error`, `path`), Spring-style field errors (`errors`), PocketBase-style field errors (`data.<field>.message`), general `message`/`detail` responses, preserves useful prefixes (e.g. `Validation/save failed.`), and falls back to the original raw string if parsing fails.

### Testing
- Attempted to build the solution with `dotnet build IISApp_front.sln`, but the command failed in this environment because `dotnet` is not installed. 
- No other automated test suites were run in this environment; the change is limited to error formatting and should not affect request flows or authentication.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09dc7eb558832a90613b78485157a9)