### PR TITLE
Migrate WPF weather client from XML-RPC to gRPC

### DIFF
--- a/IISApp/App.config
+++ b/IISApp/App.config
@@ -3,7 +3,7 @@
   <appSettings>
     <add key="ApiBaseUrl" value="http://localhost:8080" />
     <add key="SoapBaseUrl" value="http://localhost:8080" />
-    <add key="WeatherServiceUrl" value="http://localhost:9090/RPC2" />
+    <add key="WeatherGrpcAddress" value="http://localhost:9090" />
     <add key="FrontendAccessMode" value="FullAccess" />
   </appSettings>
 </configuration>

--- a/IISApp/CityWindow.xaml
+++ b/IISApp/CityWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:IISApp"
         mc:Ignorable="d"
-        Title="Weather (XML-RPC)" Height="450" Width="800">
+        Title="Weather (gRPC)" Height="450" Width="800">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -23,7 +23,7 @@
         <TextBox x:Name="CityNameTextBox" Grid.Row="0" Grid.Column="1" Margin="5"
                  FontFamily="Consolas" FontSize="12" AcceptsReturn="False" />
 
-        <Button x:Name="SendXmlRpcRequestButton" Grid.Row="1" Grid.ColumnSpan="2" Content="Get Weather via XML-RPC" Margin="5" Click="SendXmlRpcRequestButton_Click" />
+        <Button x:Name="SendXmlRpcRequestButton" Grid.Row="1" Grid.ColumnSpan="2" Content="Get Weather via gRPC" Margin="5" Click="SendXmlRpcRequestButton_Click" />
 
         <TextBlock x:Name="StatusTextBlock" Grid.Row="2" Grid.ColumnSpan="2" Margin="5" FontWeight="SemiBold" />
 

--- a/IISApp/CityWindow.xaml.cs
+++ b/IISApp/CityWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace IISApp
         public CityWindow()
         {
             InitializeComponent();
-            _client = new WeatherServiceClient(AppConfig.WeatherServiceUrl);
+            _client = new WeatherServiceClient(AppConfig.WeatherGrpcAddress);
         }
 
         private async void SendXmlRpcRequestButton_Click(object sender, RoutedEventArgs e)

--- a/IISApp/IISApp.csproj
+++ b/IISApp/IISApp.csproj
@@ -10,5 +10,15 @@
 
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.65.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.27.2" />
+    <PackageReference Include="Grpc.Tools" Version="2.65.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\weather.proto" GrpcServices="Client" />
   </ItemGroup>
 </Project>

--- a/IISApp/Protos/weather.proto
+++ b/IISApp/Protos/weather.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "hr.algebra.weather.grpc";
+option java_outer_classname = "WeatherProto";
+option csharp_namespace = "IISApp.Grpc";
+
+service WeatherGrpcService {
+  rpc GetTemperature (TemperatureRequest) returns (TemperatureResponse);
+}
+
+message TemperatureRequest {
+  string cityName = 1;
+}
+
+message TemperatureResponse {
+  repeated string results = 1;
+}

--- a/IISApp/Services/AppConfig.cs
+++ b/IISApp/Services/AppConfig.cs
@@ -9,7 +9,7 @@ namespace IISApp.Services
 
         public static string SoapBaseUrl => ReadRequired("SoapBaseUrl", ApiBaseUrl);
 
-        public static string WeatherServiceUrl => ReadRequired("WeatherServiceUrl", "http://localhost:9090/RPC2");
+        public static string WeatherGrpcAddress => ReadRequired("WeatherGrpcAddress", "http://localhost:9090");
 
         public static FrontendAccessMode AccessMode
         {

--- a/IISApp/Services/WeatherServiceClient.cs
+++ b/IISApp/Services/WeatherServiceClient.cs
@@ -1,61 +1,35 @@
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using System.Security;
-using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
-using System.Xml;
+using Grpc.Net.Client;
+using IISApp.Grpc;
 
 namespace IISApp.Services
 {
     public class WeatherServiceClient
     {
-        private readonly HttpClient _http;
+        private readonly WeatherGrpcService.WeatherGrpcServiceClient _grpcClient;
 
-        public WeatherServiceClient(string serviceUrl)
+        public WeatherServiceClient(string grpcAddress)
         {
-            _http = new HttpClient { BaseAddress = new Uri(serviceUrl) };
+            var channel = GrpcChannel.ForAddress(grpcAddress);
+            _grpcClient = new WeatherGrpcService.WeatherGrpcServiceClient(channel);
         }
 
         public async Task<IReadOnlyList<WeatherResult>> GetTemperaturesAsync(string city)
         {
-            var escapedCity = SecurityElement.Escape(city) ?? string.Empty;
-            var xmlRpcRequest = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
-<methodCall>
-    <methodName>WeatherService.getTemperature</methodName>
-    <params>
-        <param>
-            <value><string>{escapedCity}</string></value>
-        </param>
-    </params>
-</methodCall>";
-
-            using var content = new StringContent(xmlRpcRequest, new UTF8Encoding(false), "text/xml");
-            var response = await _http.PostAsync(string.Empty, content);
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new HttpRequestException($"Weather service returned status {(int)response.StatusCode}.");
-            }
-
-            var xml = await response.Content.ReadAsStringAsync();
-            return ParseTemperatures(xml);
+            var response = await _grpcClient.GetTemperatureAsync(new TemperatureRequest { CityName = city ?? string.Empty });
+            return ParseTemperatures(response.Results);
         }
 
-        private List<WeatherResult> ParseTemperatures(string xml)
+        private static IReadOnlyList<WeatherResult> ParseTemperatures(IEnumerable<string> temperatureRows)
         {
             var result = new List<WeatherResult>();
-            var doc = new XmlDocument();
-            doc.LoadXml(xml);
 
-            var valueNodes = doc.SelectNodes("/methodResponse/params/param/value/array/data/value");
-            if (valueNodes == null || valueNodes.Count == 0)
+            foreach (var row in temperatureRows)
             {
-                return result;
-            }
-
-            foreach (XmlNode valueNode in valueNodes)
-            {
-                var text = valueNode.InnerText.Trim();
+                var text = (row ?? string.Empty).Trim();
                 if (string.IsNullOrWhiteSpace(text))
                 {
                     continue;
@@ -64,16 +38,13 @@ namespace IISApp.Services
                 if (text.Contains(':'))
                 {
                     var split = text.Split(':', 2, StringSplitOptions.TrimEntries);
-                    result.Add(new WeatherResult(split[0], split[1]));
+                    var city = split.ElementAtOrDefault(0) ?? string.Empty;
+                    var temperature = split.ElementAtOrDefault(1) ?? string.Empty;
+                    result.Add(new WeatherResult(city, temperature));
+                    continue;
                 }
-                else if (text.Equals("City not found", StringComparison.OrdinalIgnoreCase))
-                {
-                    result.Add(new WeatherResult(city: string.Empty, temperature: string.Empty, message: text));
-                }
-                else
-                {
-                    result.Add(new WeatherResult(city: string.Empty, temperature: string.Empty, message: text));
-                }
+
+                result.Add(new WeatherResult(city: string.Empty, temperature: string.Empty, message: text));
             }
 
             return result;


### PR DESCRIPTION
### Motivation
- Fix the protocol mismatch where the frontend was sending XML-RPC HTTP/1.1 POSTs to a backend gRPC HTTP/2 server and eliminate the `POST /RPC2` errors. 
- Align the WPF frontend with the existing Java gRPC weather server so the UI can call `GetTemperature` directly.

### Description
- Added `IISApp/Protos/weather.proto` (matching backend proto) and enabled C# codegen in `IISApp.csproj` with a `<Protobuf Include="Protos\weather.proto" GrpcServices="Client" />` entry and NuGet packages `Grpc.Net.Client`, `Google.Protobuf`, and `Grpc.Tools`.
- Replaced `WeatherServiceUrl` with `WeatherGrpcAddress` in `IISApp/App.config` and exposed `AppConfig.WeatherGrpcAddress` with default `http://localhost:9090` in `IISApp/Services/AppConfig.cs`.
- Rewrote `IISApp/Services/WeatherServiceClient.cs` to use `GrpcChannel` and the generated `WeatherGrpcService.WeatherGrpcServiceClient`, calling `GetTemperatureAsync` and converting `TemperatureResponse.Results` into the existing `WeatherResult` model while preserving the previous string parsing behavior (e.g., `"Zagreb: 10"` and `"City not found"`).
- Updated `IISApp/CityWindow.xaml` text from XML-RPC to gRPC and changed `CityWindow` to construct `WeatherServiceClient` with `AppConfig.WeatherGrpcAddress`.

### Testing
- Attempted to build the solution with `dotnet build IISApp.sln`, but the build could not be performed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- No automated unit tests were executed in this environment due to the missing .NET SDK, so compile-time verification should be performed in a developer environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fc07926c832ab4f981dd9e63d65a)