### PR TITLE
Add local PlayersWindow validation and improve API error array formatting

### DIFF
--- a/IISApp/PlayersWindow.xaml.cs
+++ b/IISApp/PlayersWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Xml.Linq;
@@ -112,6 +113,12 @@ namespace IISApp
             var seasonText = SeasonTextBox.Text.Trim();
             var pointsText = PointsTextBox.Text.Trim();
 
+            if (!TryValidatePlayerInputs(name, team, seasonText, pointsText, out var validationError))
+            {
+                MessageBox.Show(validationError, "Player validation failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
             try
             {
                 ApiResult<Player> result;
@@ -148,6 +155,65 @@ namespace IISApp
             {
                 MessageBox.Show($"Save failed: {ex.Message}");
             }
+        }
+
+        private bool TryValidatePlayerInputs(
+            string name,
+            string team,
+            string seasonText,
+            string pointsText,
+            out string errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                errorMessage = "Name is required.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(team))
+            {
+                errorMessage = "Team is required.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(seasonText))
+            {
+                errorMessage = "Season is required.";
+                return false;
+            }
+
+            if (!int.TryParse(seasonText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var season))
+            {
+                errorMessage = "Season must be a valid whole number.";
+                return false;
+            }
+
+            if (season <= 0)
+            {
+                errorMessage = "Season must be greater than 0.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(pointsText))
+            {
+                errorMessage = "Points is required.";
+                return false;
+            }
+
+            if (!double.TryParse(pointsText, NumberStyles.Float, CultureInfo.InvariantCulture, out var points))
+            {
+                errorMessage = "Points must be a valid number.";
+                return false;
+            }
+
+            if (points < 0)
+            {
+                errorMessage = "Points must be greater than or equal to 0.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
         }
 
         private async void DeleteButton_Click(object sender, RoutedEventArgs e)

--- a/IISApp/Services/ApiService.cs
+++ b/IISApp/Services/ApiService.cs
@@ -445,6 +445,23 @@ namespace IISApp.Services
         {
             var messages = new List<string>();
 
+            if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in element.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.String)
+                    {
+                        var value = item.GetString();
+                        if (!string.IsNullOrWhiteSpace(value))
+                        {
+                            messages.Add($"- {value}");
+                        }
+                    }
+                }
+
+                return messages.Count > 0 ? string.Join(Environment.NewLine, messages) : null;
+            }
+
             if (element.ValueKind != JsonValueKind.Object)
             {
                 return null;


### PR DESCRIPTION
### Motivation
- The main `PlayersWindow` save flow sent raw textbox values to the backend without local checks, producing unclear errors for invalid numeric input.
- Backend may return array-style validation errors that were not formatted clearly for the user, so array-based messages need to be displayed nicely.

### Description
- Added a helper `TryValidatePlayerInputs(...)` to `PlayersWindow.xaml.cs` and invoked it from `SaveButton_Click` to validate `name`, `team`, `season`, and `points` before any API call, using `CultureInfo.InvariantCulture` for parsing and showing a `MessageBox` on failure so no backend request is made.
- Validation rules implemented: `name` required, `team` required, `season` required, `season` must parse as a whole `int`, `season` > 0, `points` required, `points` must parse as `double`, and `points` >= 0.
- Improved API error formatting in `IISApp/Services/ApiService.cs` by extending `ExtractFieldErrors` to handle `JsonValueKind.Array` of string errors and render them as bullet lines (prefix `- `), while preserving existing object-style error extraction.
- Changed files: `IISApp/PlayersWindow.xaml.cs` and `IISApp/Services/ApiService.cs`.

### Testing
- Ran `dotnet test IISApp.sln` but the environment lacks the .NET SDK so tests could not be executed (`dotnet: command not found`).
- No automated tests were run successfully in this environment; changes were limited and focused to frontend validation and error formatting only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a23912f04832a93bc806fca8237e7)